### PR TITLE
Route to new Dialogmote app if no moteplanlegger exists

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -54,6 +54,8 @@ spec:
       value: "https://www-gcp.dev.nav.no/syk/oppfolgingsplan"
     - name: DIALOGMOTE_URL
       value: "https://www-gcp.dev.nav.no/syk/dialogmote"
+    - name: NEW_DIALOGMOTE_URL
+      value: "https://www-gcp.dev.nav.no/syk/dialogmoter/sykmeldt"
     - name: DITTNAV_URL
       value: "https://www.dev.nav.no/person/dittnav/"
     - name: FRONTENDLOGGER_ROOT

--- a/nais-labs.yaml
+++ b/nais-labs.yaml
@@ -36,6 +36,8 @@ spec:
       value: "https://oppfolgingsplan.labs.nais.io/syk/oppfolgingsplan"
     - name: DIALOGMOTE_URL
       value: "https://dialogmote.labs.nais.io/syk/dialogmote"
+    - name: NEW_DIALOGMOTE_URL
+      value: "https://dialogmoter.labs.nais.io/syk/dialogmoter/sykmeldt"
     - name: DITTNAV_URL
       value: "https://www.nav.no/person/dittnav"
     - name: ARBEIDSSOKERREGISTRERING_URL

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -54,6 +54,8 @@ spec:
       value: "https://www.nav.no/syk/oppfolgingsplan"
     - name: DIALOGMOTE_URL
       value: "https://www.nav.no/syk/dialogmote"
+    - name: NEW_DIALOGMOTE_URL
+      value: "https://www.nav.no/syk/dialogmoter/sykmeldt"
     - name: DITTNAV_URL
       value: "https://www.nav.no/person/dittnav"
     - name: FRONTENDLOGGER_ROOT

--- a/next.config.js
+++ b/next.config.js
@@ -35,6 +35,7 @@ module.exports = withLess({
         aktivitetsplanUrl: process.env.AKTIVITETSPLAN_URL,
         oppfolgingsplanUrl: process.env.OPPFOLGINGSPLAN_URL,
         dialogmoteUrl: process.env.DIALOGMOTE_URL,
+        newDialogmoteUrl: process.env.NEW_DIALOGMOTE_URL,
         narmestelederUrl: process.env.NARMESTELEDER_URL,
         arbeidssokerregistreringUrl: process.env.ARBEIDSSOKERREGISTRERING_URL
     },

--- a/src/components/NavigationHooks/useDialogmoteUrl.ts
+++ b/src/components/NavigationHooks/useDialogmoteUrl.ts
@@ -1,0 +1,19 @@
+import useDialogmoter from '../../query-hooks/useDialogmoter'
+import { DialogMote } from '../../types/dialogmote'
+import { dialogmoteUrl, newDialogmoteUrl } from '../../utils/environment'
+
+const hasUpcomingMoteplanleggerAlternativ = (moteplanlegger: DialogMote): boolean => {
+    const today = new Date()
+
+    return moteplanlegger.alternativer?.filter(alternativ => new Date(alternativ.tid) > today).length > 0
+}
+
+export const useDialogmoteUrl = () => {
+    const moteplanleggerQuery = useDialogmoter()
+
+    if (moteplanleggerQuery.data && hasUpcomingMoteplanleggerAlternativ(moteplanleggerQuery.data)) {
+        return dialogmoteUrl()
+    }
+
+    return newDialogmoteUrl()
+}

--- a/src/components/lenker/Dialogmote.tsx
+++ b/src/components/lenker/Dialogmote.tsx
@@ -2,12 +2,14 @@ import { LenkepanelBase } from 'nav-frontend-lenkepanel'
 import { Undertittel } from 'nav-frontend-typografi'
 import React from 'react'
 
-import { dialogmoteUrl } from '../../utils/environment'
 import { tekst } from '../../utils/tekster'
+import { useDialogmoteUrl } from '../NavigationHooks/useDialogmoteUrl'
 
 export function DialogmoteLenke() {
+    const dialogmoteUrl = useDialogmoteUrl()
+
     return (
-        <LenkepanelBase href={dialogmoteUrl()} border={true}>
+        <LenkepanelBase href={dialogmoteUrl} border={true}>
             <div className="lenkeikon">
                 <svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
                     <g stroke="#3E3832" fill="none" fillRule="evenodd">

--- a/src/components/oppgaver/Oppgaver.tsx
+++ b/src/components/oppgaver/Oppgaver.tsx
@@ -11,9 +11,10 @@ import useHendelser from '../../query-hooks/useHendelser'
 import useOppfolgingsplaner from '../../query-hooks/useOppfolgingsplaner'
 import useSoknader from '../../query-hooks/useSoknader'
 import useSykmeldinger from '../../query-hooks/useSykmeldinger'
-import { dialogmoteUrl,oppfolgingsplanUrl, sykepengesoknadUrl, sykmeldingUrl } from '../../utils/environment'
+import { oppfolgingsplanUrl, sykepengesoknadUrl, sykmeldingUrl } from '../../utils/environment'
 import { tekst } from '../../utils/tekster'
 import { getAktivitetskravvisning, NYTT_AKTIVITETSKRAVVARSEL } from '../aktivitetskrav/AktivitetskravVarsel'
+import { useDialogmoteUrl } from '../NavigationHooks/useDialogmoteUrl'
 import { skapBrevOppgaver } from './brevOppgaver'
 import { skapDialogmoteBehovOppgaver } from './dialogmoteBehovOppgaver'
 import { skapDialogmoteSvarOppgaver } from './dialogmoteOppgaver'
@@ -55,13 +56,15 @@ const Oppgaver = () => {
     const { data: brev } = useBrev()
     const { data: hendelser } = useHendelser()
 
+    const dialogmoteUrl = useDialogmoteUrl()
+
 
     const soknadOppgaver = skapSøknadOppgaver(soknader, sykepengesoknadUrl())
     const sykmeldingOppgaver = skapSykmeldingoppgaver(sykmeldinger, sykmeldingUrl())
     const oppfolgingsplanoppgaver = skapOppfolgingsplanOppgaver(oppfolgingsplaner, sykmeldinger, oppfolgingsplanUrl())
-    const dialogmoteBehovOppgaver = skapDialogmoteBehovOppgaver(dialogmoteBehov, dialogmoteUrl())
-    const dialogmoteSvarOppgaver = skapDialogmoteSvarOppgaver(dialogmoteSvar, brev, dialogmoteUrl())
-    const brevOppgaver = skapBrevOppgaver(brev, dialogmoteUrl())
+    const dialogmoteBehovOppgaver = skapDialogmoteBehovOppgaver(dialogmoteBehov, dialogmoteUrl)
+    const dialogmoteSvarOppgaver = skapDialogmoteSvarOppgaver(dialogmoteSvar, brev, dialogmoteUrl)
+    const brevOppgaver = skapBrevOppgaver(brev, dialogmoteUrl)
     const oppgaver = [
         ...sykmeldingOppgaver,
         ...soknadOppgaver,

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -71,6 +71,10 @@ export function dialogmoteUrl() {
     return publicRuntimeConfig.dialogmoteUrl
 }
 
+export function newDialogmoteUrl() {
+    return publicRuntimeConfig.newDialogmoteUrl
+}
+
 export function narmestelederUrl() {
     return publicRuntimeConfig.narmestelederUrl
 }


### PR DESCRIPTION
Vi har laget ny Dialogmøte-app som skal ta over for den gamle. Den gamle skal fortsatt brukes litt til, så lenge det finnes kommende møteplanlegger-møter. 