### PR TITLE
Vis varsel for endrede referat fra dialogmøte

### DIFF
--- a/src/components/oppgaver/brevOppgaver.test.ts
+++ b/src/components/oppgaver/brevOppgaver.test.ts
@@ -45,6 +45,15 @@ it('Returnerer referat brev info oppgave når status er \'REFERAT\' og lestDato 
     } ])
 })
 
+it('Returnerer referat brev info oppgave når status er \'REFERAT_ENDRET\' og lestDato ikke er satt', () => {
+    const oppgaver = skapBrevOppgaver(brevObject(BrevType.REFERAT_ENDRET, '2021-11-08T12:35:37.669+01:00', null),'https://www.nav.no/syk/dialogmote')
+    expect(oppgaver).toEqual([ {
+        lenke: 'https://www.nav.no/syk/dialogmote',
+        tekst: 'Du har mottatt et referat fra dialogmøte',
+        oppgavetype: 'info',
+    } ])
+})
+
 it('Returnerer ingen brev oppgaver når status er \'NYTT_TID_STED\' og lestDato er satt', () => {
     const oppgaver = skapBrevOppgaver(brevObject(BrevType.ENDRING, '2021-11-08T12:35:37.669+01:00', '2021-11-01T12:35:37.669+01:00'),'https://www.nav.no/syk/dialogmote')
     expect(oppgaver).toEqual([])

--- a/src/components/oppgaver/brevOppgaver.ts
+++ b/src/components/oppgaver/brevOppgaver.ts
@@ -24,7 +24,8 @@ export const skapBrevOppgaver = (brev: Brev[] | undefined, lenke: string): Oppga
             })
             return oppgaver
         }
-        case BrevType.REFERAT: {
+        case BrevType.REFERAT:
+        case BrevType.REFERAT_ENDRET: {
             oppgaver.push({
                 tekst: tekst('oppgaver.brev.referat'),
                 oppgavetype: 'info',

--- a/src/types/brev.ts
+++ b/src/types/brev.ts
@@ -24,4 +24,5 @@ export enum BrevType {
     AVLYST= 'AVLYST',
     ENDRING='NYTT_TID_STED',
     REFERAT= 'REFERAT',
+    REFERAT_ENDRET= 'REFERAT_ENDRET',
 }


### PR DESCRIPTION
Veileder kan endre referatet fra dialogmøte, og de endrete referatene får brevtype REFERAT_ENDRET. Legger til støtte for denne typen, slik at varsel vises når den sykmeldte har fått et endret referat.