### PR TITLE
Fix code scanning alert no. 80: Server-side request forgery

### DIFF
--- a/src/hooks/useGetSykmeldingIdParam.ts
+++ b/src/hooks/useGetSykmeldingIdParam.ts
@@ -3,11 +3,13 @@ import { useRouter } from 'next/router'
 function useGetSykmeldingIdParam(): string {
     const router = useRouter()
 
-    if (typeof router.query.sykmeldingId !== 'string') {
-        throw new Error(`Illegal param: ${router.query.sykmeldingId}`)
+    const sykmeldingId = router.query.sykmeldingId
+
+    if (typeof sykmeldingId !== 'string' || !/^[a-zA-Z0-9-]+$/.test(sykmeldingId)) {
+        throw new Error(`Illegal param: ${sykmeldingId}`)
     }
 
-    return router.query.sykmeldingId
+    return sykmeldingId
 }
 
 export default useGetSykmeldingIdParam


### PR DESCRIPTION
Fixes [https://github.com/navikt/ditt-sykefravaer/security/code-scanning/80](https://github.com/navikt/ditt-sykefravaer/security/code-scanning/80)

To fix the SSRF vulnerability, we need to validate the `sykmeldingId` parameter before using it to construct the URL. We can implement an allow-list of valid `sykmeldingId` values or use a regular expression to ensure that the `sykmeldingId` conforms to an expected format. This will prevent attackers from injecting malicious URLs.

1. Implement a validation function to check the `sykmeldingId` against an allow-list or a regular expression.
2. Use this validation function in `useGetSykmeldingIdParam` to ensure the `sykmeldingId` is valid before returning it.
3. Update the `fetchMedRequestId` function to handle invalid `sykmeldingId` values appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
