### PR TITLE
Disabler autoinstrumentering grunnet produksjon problemer

### DIFF
--- a/nais/app/naiserator.yaml
+++ b/nais/app/naiserator.yaml
@@ -22,7 +22,7 @@ spec:
       port: 3000
   observability:
     autoInstrumentation:
-      enabled: true
+      enabled: false
       runtime: nodejs
     logging:
       destinations:


### PR DESCRIPTION
Invalid JWT token found (cause: Client network socket disconnected before secure TLS connection was established, redirecting to login.: Client network socket disconnected before secure TLS connection was established