### PR TITLE
Rute brukere mellom ny og gammel sykmelding app

### DIFF
--- a/src/pages/sykmelding/index.tsx
+++ b/src/pages/sykmelding/index.tsx
@@ -1,13 +1,12 @@
 import React, { ReactElement } from 'react'
 import Head from 'next/head'
-import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next/types'
 
 import Header from '../../components/Header/Header'
 import SykmeldingerListAll from '../../components/SykmeldingerList/SykmeldingerListAll'
 import TilHovedsiden from '../../components/TilHovedsiden/TilHovedsiden'
 import PageWrapper from '../../components/PageWrapper/PageWrapper'
 import { useUpdateBreadcrumbs } from '../../hooks/useBreadcrumbs'
-import { beskyttetSideUtenProps, ServerSidePropsResult } from '../../auth/beskyttetSide'
+import { beskyttetSideUtenProps } from '../../auth/beskyttetSide'
 
 function SykmeldingerPage(): ReactElement {
     useUpdateBreadcrumbs(() => [])
@@ -28,10 +27,6 @@ function SykmeldingerPage(): ReactElement {
     )
 }
 
-export async function getServerSideProps(
-    context: GetServerSidePropsContext,
-): Promise<GetServerSidePropsResult<ServerSidePropsResult>> {
-    return beskyttetSideUtenProps(context)
-}
+export const getServerSideProps = beskyttetSideUtenProps
 
 export default SykmeldingerPage

--- a/src/pages/sykmelding/index.tsx
+++ b/src/pages/sykmelding/index.tsx
@@ -1,12 +1,14 @@
 import React, { ReactElement } from 'react'
 import Head from 'next/head'
+import { GetServerSidePropsContext, GetServerSidePropsResult } from 'next/types'
 
 import Header from '../../components/Header/Header'
 import SykmeldingerListAll from '../../components/SykmeldingerList/SykmeldingerListAll'
 import TilHovedsiden from '../../components/TilHovedsiden/TilHovedsiden'
 import PageWrapper from '../../components/PageWrapper/PageWrapper'
 import { useUpdateBreadcrumbs } from '../../hooks/useBreadcrumbs'
-import { beskyttetSideUtenProps } from '../../auth/beskyttetSide'
+import { beskyttetSideUtenProps, ServerSidePropsResult } from '../../auth/beskyttetSide'
+import { getFlagsServerSide } from '../../toggles/ssr'
 
 function SykmeldingerPage(): ReactElement {
     useUpdateBreadcrumbs(() => [])
@@ -27,6 +29,30 @@ function SykmeldingerPage(): ReactElement {
     )
 }
 
-export const getServerSideProps = beskyttetSideUtenProps
+export async function getServerSideProps(
+    context: GetServerSidePropsContext,
+): Promise<GetServerSidePropsResult<ServerSidePropsResult>> {
+    // Get flags first to check gradual rollout toggle
+    const flags = await getFlagsServerSide(context.req, context.res)
+
+    const gradualRolloutToggle = flags.toggles.find(
+        (toggle) => toggle.name === 'ditt-sykefravaer-sykmelding-gradual-rollout',
+    )
+
+    if (!gradualRolloutToggle?.enabled) {
+        // TODO: Replace with the actual URL of the old sykmelding app
+        const oldAppUrl = process.env.OLD_SYKMELDING_APP_URL || 'https://old-sykmelding-app.nav.no/sykmelding'
+
+        return {
+            redirect: {
+                destination: oldAppUrl,
+                permanent: false,
+            },
+        }
+    }
+
+    // If toggle is enabled, use the standard beskyttetSideUtenProps flow
+    return beskyttetSideUtenProps(context)
+}
 
 export default SykmeldingerPage

--- a/src/pages/sykmelding/index.tsx
+++ b/src/pages/sykmelding/index.tsx
@@ -8,8 +8,6 @@ import TilHovedsiden from '../../components/TilHovedsiden/TilHovedsiden'
 import PageWrapper from '../../components/PageWrapper/PageWrapper'
 import { useUpdateBreadcrumbs } from '../../hooks/useBreadcrumbs'
 import { beskyttetSideUtenProps, ServerSidePropsResult } from '../../auth/beskyttetSide'
-import { getFlagsServerSide } from '../../toggles/ssr'
-import { sykmeldingUrl } from '../../utils/environment'
 
 function SykmeldingerPage(): ReactElement {
     useUpdateBreadcrumbs(() => [])
@@ -33,22 +31,7 @@ function SykmeldingerPage(): ReactElement {
 export async function getServerSideProps(
     context: GetServerSidePropsContext,
 ): Promise<GetServerSidePropsResult<ServerSidePropsResult>> {
-    const flags = await getFlagsServerSide(context.req, context.res)
-    const gradualRolloutToggle = flags.toggles.find(
-        (toggle) => toggle.name === 'ditt-sykefravaer-sykmelding-gradvis-utrulling',
-    )
-
-    if (!gradualRolloutToggle?.enabled) {
-        const oldAppUrl = sykmeldingUrl()
-        return {
-            redirect: {
-                destination: oldAppUrl,
-                permanent: false,
-            },
-        }
-    } else {
-        return beskyttetSideUtenProps(context)
-    }
+    return beskyttetSideUtenProps(context)
 }
 
 export default SykmeldingerPage

--- a/src/pages/sykmelding/index.tsx
+++ b/src/pages/sykmelding/index.tsx
@@ -9,6 +9,7 @@ import PageWrapper from '../../components/PageWrapper/PageWrapper'
 import { useUpdateBreadcrumbs } from '../../hooks/useBreadcrumbs'
 import { beskyttetSideUtenProps, ServerSidePropsResult } from '../../auth/beskyttetSide'
 import { getFlagsServerSide } from '../../toggles/ssr'
+import { sykmeldingUrl } from '../../utils/environment'
 
 function SykmeldingerPage(): ReactElement {
     useUpdateBreadcrumbs(() => [])
@@ -32,27 +33,22 @@ function SykmeldingerPage(): ReactElement {
 export async function getServerSideProps(
     context: GetServerSidePropsContext,
 ): Promise<GetServerSidePropsResult<ServerSidePropsResult>> {
-    // Get flags first to check gradual rollout toggle
     const flags = await getFlagsServerSide(context.req, context.res)
-
     const gradualRolloutToggle = flags.toggles.find(
-        (toggle) => toggle.name === 'ditt-sykefravaer-sykmelding-gradual-rollout',
+        (toggle) => toggle.name === 'ditt-sykefravaer-sykmelding-gradvis-utrulling',
     )
 
     if (!gradualRolloutToggle?.enabled) {
-        // TODO: Replace with the actual URL of the old sykmelding app
-        const oldAppUrl = process.env.OLD_SYKMELDING_APP_URL || 'https://old-sykmelding-app.nav.no/sykmelding'
-
+        const oldAppUrl = sykmeldingUrl()
         return {
             redirect: {
                 destination: oldAppUrl,
                 permanent: false,
             },
         }
+    } else {
+        return beskyttetSideUtenProps(context)
     }
-
-    // If toggle is enabled, use the standard beskyttetSideUtenProps flow
-    return beskyttetSideUtenProps(context)
 }
 
 export default SykmeldingerPage

--- a/src/toggles/toggles.ts
+++ b/src/toggles/toggles.ts
@@ -4,4 +4,5 @@ export const EXPECTED_TOGGLES = [
     'ditt-sykefravaer-maxdato',
     'flexjar-ditt-sykefravaer-inntektsmelding-visning',
     'flexjar-sykmelding-kvittering',
+    'ditt-sykefravaer-sykmelding-gradual-rollout',
 ] as const

--- a/src/toggles/toggles.ts
+++ b/src/toggles/toggles.ts
@@ -4,5 +4,5 @@ export const EXPECTED_TOGGLES = [
     'ditt-sykefravaer-maxdato',
     'flexjar-ditt-sykefravaer-inntektsmelding-visning',
     'flexjar-sykmelding-kvittering',
-    'ditt-sykefravaer-sykmelding-gradual-rollout',
+    'ditt-sykefravaer-sykmelding-gradvis-utrulling',
 ] as const


### PR DESCRIPTION
Fra tidligere redirecter /sykmeldinger -> https://www.nav.no/syk/sykmeldinger (tsm sykmelding app)

Her endres det slik at Unleash brukes til å redirecte:

/sykmeldinger -> /sykmelding (ny app): dersom feature toggle er på
/sykmeldinger -> https://www.nav.no/syk/sykmeldinger: dersom feature toggle er av