### PR TITLE
Send legacy-oppgaver for oppfølgingsplan til gammel løsning

### DIFF
--- a/src/components/oppgaver/Oppgaver.tsx
+++ b/src/components/oppgaver/Oppgaver.tsx
@@ -5,7 +5,7 @@ import useMeldinger from '../../hooks/useMeldinger'
 import useOppfolgingsplaner from '../../hooks/useOppfolgingsplaner'
 import useSoknader from '../../hooks/useSoknader'
 import useTsmSykmeldinger from '../../hooks/useDittSykefravaerSykmeldinger'
-import { basePath, oppfolgingsplanUrl, sykepengesoknadUrl } from '../../utils/environment'
+import { basePath, gammelOppfolgingsplanUrl, sykepengesoknadUrl } from '../../utils/environment'
 import { tekst } from '../../utils/tekster'
 import { logEvent } from '../umami/umami'
 import { fetchMedRequestId } from '../../utils/fetch'
@@ -131,7 +131,11 @@ function Oppgaver() {
 
     const soknadOppgaver = skapSoknadOppgaver(soknader, sykepengesoknadUrl())
     const sykmeldingOppgaver = skapSykmeldingoppgaver(sykmeldinger, basePath() + '/sykmeldinger')
-    const oppfolgingsplanoppgaver = skapOppfolgingsplanOppgaver(oppfolgingsplaner, sykmeldinger, oppfolgingsplanUrl())
+    const oppfolgingsplanoppgaver = skapOppfolgingsplanOppgaver(
+        oppfolgingsplaner,
+        sykmeldinger,
+        gammelOppfolgingsplanUrl(),
+    )
 
     const meldingerOppgaver = skapMeldinger(meldinger)
 

--- a/src/components/oppgaver/oppfolgingsplanOppgaver.test.ts
+++ b/src/components/oppgaver/oppfolgingsplanOppgaver.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from 'vitest'
+
+import { avventendeUnderArbeid, nyUnderArbeid } from '../../data/mock/data/oppfolgingsplaner'
+import { sendtSykmelding } from '../../data/mock/data/sykmeldinger'
+
+import { skapOppfolgingsplanOppgaver } from './oppfolgingsplanOppgaver'
+
+const legacyUrl = 'http://example.com/oppfolgingsplaner/sykmeldt'
+
+it('returnerer en legacy-oppgave for nye planer med gammel url', () => {
+    const oppgaver = skapOppfolgingsplanOppgaver([{ ...nyUnderArbeid }], [{ ...sendtSykmelding }], legacyUrl)
+
+    expect(oppgaver).toEqual([
+        {
+            lenke: legacyUrl,
+            tekst: 'Arbeidsgiveren din har begynt på en oppfølgingsplan. Du skal fylle ut din del.',
+        },
+    ])
+})
+
+it('returnerer en legacy-oppgave for avventende godkjenning med gammel url', () => {
+    const oppgaver = skapOppfolgingsplanOppgaver(
+        [
+            {
+                ...avventendeUnderArbeid,
+                godkjenninger: [...avventendeUnderArbeid.godkjenninger],
+            },
+        ],
+        [{ ...sendtSykmelding }],
+        legacyUrl,
+    )
+
+    expect(oppgaver).toEqual([
+        {
+            lenke: legacyUrl,
+            tekst: 'Du har en oppfølgingsplan som venter på godkjenning av deg',
+        },
+    ])
+})

--- a/src/utils/environment.test.ts
+++ b/src/utils/environment.test.ts
@@ -1,15 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { mockPublicRuntimeConfig } from './test/mockRuntimeConfig'
-import { gammelOppfolgingsplanUrl, oppfolgingsplanUrl } from './environment'
-
-describe('gammelOppfolgingsplanUrl', () => {
-    it('bruker alltid gammel url', () => {
-        mockPublicRuntimeConfig.nyOppfolgingsplanEnabled = 'true'
-
-        expect(gammelOppfolgingsplanUrl()).toEqual(mockPublicRuntimeConfig.oppfolgingsplanUrl)
-    })
-})
+import { oppfolgingsplanUrl } from './environment'
 
 describe('oppfolgingsplanUrl', () => {
     it('bruker gammel url når ny oppfolgingsplan ikke er aktivert', () => {

--- a/src/utils/environment.test.ts
+++ b/src/utils/environment.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
 import { mockPublicRuntimeConfig } from './test/mockRuntimeConfig'
-import { oppfolgingsplanUrl } from './environment'
+import { gammelOppfolgingsplanUrl, oppfolgingsplanUrl } from './environment'
+
+describe('gammelOppfolgingsplanUrl', () => {
+    it('bruker alltid gammel url', () => {
+        mockPublicRuntimeConfig.nyOppfolgingsplanEnabled = 'true'
+
+        expect(gammelOppfolgingsplanUrl()).toEqual(mockPublicRuntimeConfig.oppfolgingsplanUrl)
+    })
+})
 
 describe('oppfolgingsplanUrl', () => {
     it('bruker gammel url når ny oppfolgingsplan ikke er aktivert', () => {

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -38,11 +38,15 @@ function nyOppfolgingsplanEnabled() {
     return publicRuntimeConfig.nyOppfolgingsplanEnabled === 'true'
 }
 
+export function gammelOppfolgingsplanUrl() {
+    return publicRuntimeConfig.oppfolgingsplanUrl
+}
+
 export function oppfolgingsplanUrl() {
     if (nyOppfolgingsplanEnabled()) {
         return publicRuntimeConfig.nyOppfolgingsplanUrl
     }
-    return publicRuntimeConfig.oppfolgingsplanUrl
+    return gammelOppfolgingsplanUrl()
 }
 
 export function dialogmoteUrl() {


### PR DESCRIPTION
## Oppsummering
- sender oppgaver for oppfølgingsplan som kommer fra legacy-data til gammel oppfølgingsplan-URL
- lar generiske innganger til oppfølgingsplan fortsatt bruke togglet/standard URL
- legger til tester for legacy-URL-helperen og lenking fra legacy-oppgaver