### PR TITLE
Vis opt-in info kun for sykmeldinger innenfor ventetiden

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,8 @@ Testfiler ligger i `playwright/` og er organisert etter domene:
 
 **Eksempel:**
 ```ts
+import { expect, test } from '../utils/fixtures'
 import { gotoScenario } from '../utils/user-actions'
-import { test } from '../utils/fixtures'
-import { expect } from '@playwright/test'
 
 test('viser riktig innhold', async ({ page }) => {
     await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: false })(page)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,16 @@ Testfiler ligger i `playwright/` og er organisert etter domene:
 | `gotoScenario(scenario, opts)` | `utils/user-actions` | Naviger til scenario |
 | `navigateToFirstSykmelding(type, variant)` | `utils/user-actions` | Åpne første sykmelding i liste |
 
-**Negasjoner** (`not.toBeVisible()`) skrives fortsatt med `expect` direkte — hjelpefunksjonene støtter ikke negasjon.
+**Negasjoner** (`not.toBeVisible()`) skrives med `expect` direkte og ved å hente locatoren selv. `harSynligOverskrift` og `harSynligTekst` returnerer nok locatoren, men kaller `expect(locator).toBeVisible()` internt — testen vil feile der før du rekker å bruke `.not`.
+
+```ts
+// ✅ Riktig for negasjon
+await expect(page.getByRole('heading', { name: 'Hva skjer videre?', level: 2 })).not.toBeVisible()
+
+// ❌ Vil feile inne i hjelpefunksjonen
+const locator = await harSynligOverskrift(page, 'Hva skjer videre?', 2) // kaster her
+await expect(locator).not.toBeVisible()
+```
 
 **Tilgjengelige scenario-parametre i `gotoScenario()`:**
 - `erUtenforVentetid: boolean` — styrer ventetid-svar fra mock-backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,20 @@ npx playwright test playwright/sykmelding  # kun sykmelding-tester
 npx playwright test --ui                 # interaktiv UI-modus
 ```
 
+## Git-commits
+
+Commit-meldinger skal være **korte og beskrivende** på norsk eller engelsk — uten konvensjonelle prefikser som `feat:`, `fix:`, `chore:` o.l.
+
+```bash
+# ✅ Riktig
+git commit -m "Vis opt-in info kun for sykmeldinger innenfor ventetiden"
+git commit -m "Legg til Playwright-tester for ventetid-filtrering"
+
+# ❌ Feil
+git commit -m "feat: vis opt-in info kun for sykmeldinger innenfor ventetiden"
+git commit -m "fix: bruk fixtures-import for expect"
+```
+
 ## Viktige mønstre
 
 ### Mock-backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md — Copilot-instruksjoner for ditt-sykefravaer
+
+## Prosjekt
+Next.js-frontend for sykmeldte brukere. Stack: TypeScript, Next.js, Aksel Design System, React Query.
+
+## Testing
+
+### Playwright E2E-tester (obligatorisk ved ny funksjonalitet)
+Alle nye funksjoner og endringer i brukerflyt **skal** følges av Playwright-tester.
+
+Testfiler ligger i `playwright/` og er organisert etter domene:
+- `playwright/sykmelding/` — sykmeldingrelaterte tester
+- `playwright/*.spec.ts` — øvrige tester
+
+**Når du skal skrive Playwright-tester:**
+1. Legg testen i riktig undermappe under `playwright/`
+2. Importer fixtures fra `playwright/utils/fixtures` (ikke direkte fra `@playwright/test`)
+3. Bruk `gotoScenario()` fra `playwright/utils/user-actions` for å sette opp tilstand
+4. Bruk `navigateToFirstSykmelding()` der du trenger å åpne en spesifikk sykmelding
+5. Opprett nye scenarios i `src/data/mock/mock-db/scenarios.ts` ved behov
+6. Utvid `SykmeldingBuilder` i `src/data/mock/mock-db/data-creators.ts` om testdataen mangler
+
+**Tilgjengelige scenario-parametre i `gotoScenario()`:**
+- `erUtenforVentetid: boolean` — styrer ventetid-svar fra mock-backend
+- `antallArbeidsgivere: 0 | 1 | 2 | 3 | 4`
+- `erForsteSykmelding: boolean`
+
+**Eksempel:**
+```ts
+import { gotoScenario } from '../utils/user-actions'
+import { test } from '../utils/fixtures'
+import { expect } from '@playwright/test'
+
+test('viser riktig innhold', async ({ page }) => {
+    await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: false })(page)
+    await expect(page.getByRole('heading', { name: 'Hva skjer videre?' })).toBeVisible()
+})
+```
+
+### Kjøre tester lokalt
+```bash
+npx playwright test                      # alle tester (Chrome)
+npx playwright test playwright/sykmelding  # kun sykmelding-tester
+npx playwright test --ui                 # interaktiv UI-modus
+```
+
+## Viktige mønstre
+
+### Mock-backend
+Mock-data styres via URL-parametre (scenario, erUtenforVentetid, etc.) og håndteres i:
+- `src/data/mock/mock-db/scenarios.ts` — scenarioliste
+- `src/data/mock/mock-db/MockDb.ts` — tilstandsmaskin for mock
+- `src/auth/mock-context.ts` — parser URL-parametre og setter tilstand
+
+### React Query hooks
+Hooks for API-kall ligger i `src/hooks/sykmelding/`. Bruk `enabled`-parameteren for å unngå unødige kall.
+
+### Betinget rendering basert på ventetid
+Bruk `useErUtenforVentetid(sykmeldingId, enabled)` og sjekk `data?.erUtenforVentetid === false` for å vise innhold kun innenfor ventetiden.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,31 @@ Testfiler ligger i `playwright/` og er organisert etter domene:
 
 **Når du skal skrive Playwright-tester:**
 1. Legg testen i riktig undermappe under `playwright/`
-2. Importer fixtures fra `playwright/utils/fixtures` (ikke direkte fra `@playwright/test`)
-3. Bruk `gotoScenario()` fra `playwright/utils/user-actions` for å sette opp tilstand
-4. Bruk `navigateToFirstSykmelding()` der du trenger å åpne en spesifikk sykmelding
-5. Opprett nye scenarios i `src/data/mock/mock-db/scenarios.ts` ved behov
-6. Utvid `SykmeldingBuilder` i `src/data/mock/mock-db/data-creators.ts` om testdataen mangler
+2. Importer `test` og `expect` fra `playwright/utils/fixtures` (ikke direkte fra `@playwright/test`)
+3. Bruk hjelpefunksjonene i `playwright/utils/` fremfor rå `page.getBy*`-kall (se tabell under)
+4. Bruk `gotoScenario()` fra `playwright/utils/user-actions` for å sette opp tilstand
+5. Bruk `navigateToFirstSykmelding()` der du trenger å åpne en spesifikk sykmelding
+6. Legg til `validerAxe(page, testInfo)` på positive tester for tilgjengelighetssjekk
+7. Opprett nye scenarios i `src/data/mock/mock-db/scenarios.ts` ved behov
+8. Utvid `SykmeldingBuilder` i `src/data/mock/mock-db/data-creators.ts` om testdataen mangler
+
+### Playwright-utils — bruk disse fremfor rå page-kall
+
+| Funksjon | Fra | Bruksområde |
+|----------|-----|-------------|
+| `harSynligOverskrift(page, tekst, level)` | `utils/test-utils` | Sjekk at en heading er synlig |
+| `harSynligTekst(page, tekst)` | `utils/test-utils` | Sjekk at en tekst er synlig |
+| `apneReadmore(page, tittel, [forventetTekst])` | `utils/test-utils` | Åpne ReadMore og verifiser innhold |
+| `getRadioInGroup(page)(group, radio)` | `utils/test-utils` | Velg radioknapp i gruppe |
+| `getCheckboxInGroup(page)(group, cb)` | `utils/test-utils` | Velg checkbox i gruppe |
+| `validerAxe(page, testInfo)` | `utils/uuvalidering` | WCAG-sjekk (legg til på positive tester) |
+| `validerCLS(getCLS, navn)` | `utils/cls-validering` | Layout stability-sjekk |
+| `expectKvittering(opts)` | `utils/user-expects` | Verifiser kvitteringsside (SENDT) |
+| `expectDineSvar(svar)` | `utils/user-expects` | Verifiser brukerens svar-seksjon |
+| `gotoScenario(scenario, opts)` | `utils/user-actions` | Naviger til scenario |
+| `navigateToFirstSykmelding(type, variant)` | `utils/user-actions` | Åpne første sykmelding i liste |
+
+**Negasjoner** (`not.toBeVisible()`) skrives fortsatt med `expect` direkte — hjelpefunksjonene støtter ikke negasjon.
 
 **Tilgjengelige scenario-parametre i `gotoScenario()`:**
 - `erUtenforVentetid: boolean` — styrer ventetid-svar fra mock-backend
@@ -29,10 +49,18 @@ Testfiler ligger i `playwright/` og er organisert etter domene:
 ```ts
 import { expect, test } from '../utils/fixtures'
 import { gotoScenario } from '../utils/user-actions'
+import { apneReadmore, harSynligOverskrift, harSynligTekst } from '../utils/test-utils'
+import { validerAxe } from '../utils/uuvalidering'
 
-test('viser riktig innhold', async ({ page }) => {
+test('viser riktig innhold', async ({ page }, testInfo) => {
     await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: false })(page)
-    await expect(page.getByRole('heading', { name: 'Hva skjer videre?' })).toBeVisible()
+    await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
+
+    await harSynligOverskrift(page, 'Hva skjer videre?', 2)
+    await harSynligTekst(page, 'Hvis du er syk i mindre enn 16 dager')
+    await apneReadmore(page, 'Om din rett til å søke om sykepenger', ['Det er Nav som avgjør'])
+
+    await validerAxe(page, testInfo)
 })
 ```
 

--- a/playwright/sykmelding/arbeidssituasjon-nullstill.spec.tsx
+++ b/playwright/sykmelding/arbeidssituasjon-nullstill.spec.tsx
@@ -115,6 +115,5 @@ test.describe('Nullstilling av brukersvar ved bytte av arbeidssituasjon', () => 
         await sendSykmelding(page)
 
         await expect(page.getByText('Sykmeldingen ble sendt')).toBeVisible()
-        await page.unrouteAll({ behavior: 'ignoreErrors' })
     })
 })

--- a/playwright/sykmelding/fiskere.spec.tsx
+++ b/playwright/sykmelding/fiskere.spec.tsx
@@ -60,7 +60,6 @@ test.describe('Arbeidssituasjon - Fiskere', () => {
             ).toBeVisible()
 
             await expect(page.getByRole('button', { name: /Bekreft sykmelding/ })).toBeDisabled()
-            await page.unrouteAll({ behavior: 'ignoreErrors' })
         })
 
         test('should disable submit button when er-utenfor-ventetid fails', async ({ page }) => {
@@ -85,7 +84,6 @@ test.describe('Arbeidssituasjon - Fiskere', () => {
             ).toBeVisible()
 
             await expect(page.getByRole('button', { name: /Bekreft sykmelding/ })).toBeDisabled()
-            await page.unrouteAll({ behavior: 'ignoreErrors' })
         })
 
         test('should disable submit button while er-forste-sykmelding is loading', async ({ page }) => {

--- a/playwright/sykmelding/frilanser.spec.tsx
+++ b/playwright/sykmelding/frilanser.spec.tsx
@@ -65,7 +65,6 @@ test.describe('Frilanser', () => {
             ).toBeVisible()
 
             await expect(page.getByRole('button', { name: /Bekreft sykmelding/ })).toBeDisabled()
-            await page.unrouteAll({ behavior: 'ignoreErrors' })
         })
 
         test('should disable submit button when er-utenfor-ventetid fails', async ({ page }) => {
@@ -92,7 +91,6 @@ test.describe('Frilanser', () => {
             ).toBeVisible()
 
             await expect(page.getByRole('button', { name: /Bekreft sykmelding/ })).toBeDisabled()
-            await page.unrouteAll({ behavior: 'ignoreErrors' })
         })
 
         test('should disable submit button while er-forste-sykmelding is loading', async ({ page }) => {

--- a/playwright/sykmelding/optIn.spec.tsx
+++ b/playwright/sykmelding/optIn.spec.tsx
@@ -79,6 +79,45 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
         await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
     })
 
+    test('viser info-alert etter vellykket opt-in', async ({ page }) => {
+        let optInCalled = false
+        await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/opt-in*', (route) => {
+            if (route.request().method() === 'POST') {
+                optInCalled = true
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ status: 'ok' }),
+                })
+            }
+            return route.continue()
+        })
+
+        await gotoScenario('normal', {
+            erForsteSykmelding: false,
+            erUtenforVentetid: true,
+        })(page)
+        await navigateToFirstSykmelding('nye', '100%')(page)
+        await opplysingeneStemmer(page)
+        await velgArbeidssituasjon('frilanser')(page)
+        await bekreftSykmelding(page)
+
+        await page.waitForURL('**/kvittering')
+
+        await page.getByRole('button', { name: 'Om din rett til å søke om sykepenger' }).click()
+        await page.getByRole('button', { name: 'Jeg vil søke om sykepenger' }).click()
+
+        expect(optInCalled).toBe(true)
+        await expect(
+            page.getByRole('heading', { name: 'Vi oppretter søknad etter sykmeldingsperioden er over' }),
+        ).toBeVisible()
+        await expect(
+            page.getByText(
+                'Du vil få beskjed av oss når du skal fylle ut og sende inn søknaden om sykepenger for sykmeldingsperioden.',
+            ),
+        ).toBeVisible()
+    })
+
     test('kaller opt-in-endepunktet når knappen trykkes', async ({ page }) => {
         let optInCalled = false
         await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/opt-in*', (route) => {

--- a/playwright/sykmelding/optIn.spec.tsx
+++ b/playwright/sykmelding/optIn.spec.tsx
@@ -1,0 +1,150 @@
+import { expect, test } from '@playwright/test'
+
+import {
+    bekreftSykmelding,
+    gotoScenario,
+    navigateToFirstSykmelding,
+    opplysingeneStemmer,
+    velgArbeidssituasjon,
+} from '../utils/user-actions'
+
+test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
+    test('should show opt-in button when no søknad exists', async ({ page }) => {
+        await gotoScenario('normal', {
+            erForsteSykmelding: false,
+            erUtenforVentetid: true,
+        })(page)
+        await navigateToFirstSykmelding('nye', '100%')(page)
+        await opplysingeneStemmer(page)
+        await velgArbeidssituasjon('frilanser')(page)
+        await bekreftSykmelding(page)
+
+        await page.waitForURL('**/kvittering')
+
+        const readMore = page.getByRole('button', { name: 'Om din rett til å søke om sykepenger' })
+        await expect(readMore).toBeVisible()
+        await readMore.click()
+
+        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).toBeVisible()
+    })
+
+    test('should show alert text when søknad already exists', async ({ page }) => {
+        await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/har-soknad*', (route) => {
+            if (route.request().method() === 'GET') {
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ harSoknad: true }),
+                })
+            }
+            return route.continue()
+        })
+
+        await gotoScenario('normal', {
+            erForsteSykmelding: false,
+            erUtenforVentetid: true,
+        })(page)
+        await navigateToFirstSykmelding('nye', '100%')(page)
+        await opplysingeneStemmer(page)
+        await velgArbeidssituasjon('frilanser')(page)
+        await bekreftSykmelding(page)
+
+        await page.waitForURL('**/kvittering')
+
+        const readMore = page.getByRole('button', { name: 'Om din rett til å søke om sykepenger' })
+        await expect(readMore).toBeVisible()
+        await readMore.click()
+
+        await expect(page.getByText('Du har en søknad for denne perioden.')).toBeVisible()
+        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
+    })
+
+    test('should call opt-in endpoint when button is clicked', async ({ page }) => {
+        let optInCalled = false
+        await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/opt-in*', (route) => {
+            if (route.request().method() === 'POST') {
+                optInCalled = true
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ status: 'ok' }),
+                })
+            }
+            return route.continue()
+        })
+
+        await gotoScenario('normal', {
+            erForsteSykmelding: false,
+            erUtenforVentetid: true,
+        })(page)
+        await navigateToFirstSykmelding('nye', '100%')(page)
+        await opplysingeneStemmer(page)
+        await velgArbeidssituasjon('frilanser')(page)
+        await bekreftSykmelding(page)
+
+        await page.waitForURL('**/kvittering')
+
+        await page.getByRole('button', { name: 'Om din rett til å søke om sykepenger' }).click()
+        await page.getByRole('button', { name: 'Jeg vil søke om sykepenger' }).click()
+
+        expect(optInCalled).toBe(true)
+    })
+
+    test('should show error alert when har-soknad call fails', async ({ page }) => {
+        await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/har-soknad*', (route) => {
+            if (route.request().method() === 'GET') {
+                return route.fulfill({
+                    status: 500,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ message: 'Internal Server Error' }),
+                })
+            }
+            return route.continue()
+        })
+
+        await gotoScenario('normal', {
+            erForsteSykmelding: false,
+            erUtenforVentetid: true,
+        })(page)
+        await navigateToFirstSykmelding('nye', '100%')(page)
+        await opplysingeneStemmer(page)
+        await velgArbeidssituasjon('frilanser')(page)
+        await bekreftSykmelding(page)
+
+        await page.waitForURL('**/kvittering')
+
+        await page.getByRole('button', { name: 'Om din rett til å søke om sykepenger' }).click()
+
+        await expect(page.getByText('Beklager, en feil oppstod. Vennligst prøv igjen senere.')).toBeVisible()
+        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
+    })
+
+    test('should show error alert when opt-in call fails', async ({ page }) => {
+        await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/opt-in*', (route) => {
+            if (route.request().method() === 'POST') {
+                return route.fulfill({
+                    status: 500,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ message: 'Internal Server Error' }),
+                })
+            }
+            return route.continue()
+        })
+
+        await gotoScenario('normal', {
+            erForsteSykmelding: false,
+            erUtenforVentetid: true,
+        })(page)
+        await navigateToFirstSykmelding('nye', '100%')(page)
+        await opplysingeneStemmer(page)
+        await velgArbeidssituasjon('frilanser')(page)
+        await bekreftSykmelding(page)
+
+        await page.waitForURL('**/kvittering')
+
+        await page.getByRole('button', { name: 'Om din rett til å søke om sykepenger' }).click()
+        await page.getByRole('button', { name: 'Jeg vil søke om sykepenger' }).click()
+
+        await expect(page.getByText('Beklager, en feil oppstod. Vennligst prøv igjen senere.')).toBeVisible()
+    })
+})

--- a/playwright/sykmelding/optIn.spec.tsx
+++ b/playwright/sykmelding/optIn.spec.tsx
@@ -9,7 +9,7 @@ import {
 } from '../utils/user-actions'
 
 test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
-    test('should show opt-in button when no søknad exists', async ({ page }) => {
+    test('viser opt-in-knapp når ingen søknad finnes', async ({ page }) => {
         await gotoScenario('normal', {
             erForsteSykmelding: false,
             erUtenforVentetid: true,
@@ -28,7 +28,7 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
         await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).toBeVisible()
     })
 
-    test('should show alert text when søknad already exists', async ({ page }) => {
+    test('viser varsel når søknad allerede finnes', async ({ page }) => {
         await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/har-soknad*', (route) => {
             if (route.request().method() === 'GET') {
                 return route.fulfill({
@@ -59,7 +59,7 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
         await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
     })
 
-    test('should call opt-in endpoint when button is clicked', async ({ page }) => {
+    test('kaller opt-in-endepunktet når knappen trykkes', async ({ page }) => {
         let optInCalled = false
         await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/opt-in*', (route) => {
             if (route.request().method() === 'POST') {
@@ -90,7 +90,7 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
         expect(optInCalled).toBe(true)
     })
 
-    test('should show error alert when har-soknad call fails', async ({ page }) => {
+    test('viser feilvarsel når har-soknad-kallet feiler', async ({ page }) => {
         await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/har-soknad*', (route) => {
             if (route.request().method() === 'GET') {
                 return route.fulfill({
@@ -119,7 +119,7 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
         await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
     })
 
-    test('should show error alert when opt-in call fails', async ({ page }) => {
+    test('viser feilvarsel når opt-in-kallet feiler', async ({ page }) => {
         await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/opt-in*', (route) => {
             if (route.request().method() === 'POST') {
                 return route.fulfill({
@@ -146,5 +146,43 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
         await page.getByRole('button', { name: 'Jeg vil søke om sykepenger' }).click()
 
         await expect(page.getByText('Beklager, en feil oppstod. Vennligst prøv igjen senere.')).toBeVisible()
+    })
+
+    test('viser varsel når sykmeldingen er eldre enn 4 måneder', async ({ page }) => {
+        await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/id-apen-sykmelding', async (route) => {
+            if (route.request().method() === 'GET') {
+                const response = await route.fetch()
+                const json = await response.json()
+                json.sykmeldingStatus.timestamp = new Date('2025-01-01').toISOString()
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify(json),
+                })
+            }
+            return route.continue()
+        })
+
+        await gotoScenario('normal', {
+            erForsteSykmelding: false,
+            erUtenforVentetid: true,
+        })(page)
+        await navigateToFirstSykmelding('nye', '100%')(page)
+        await opplysingeneStemmer(page)
+        await velgArbeidssituasjon('frilanser')(page)
+        await bekreftSykmelding(page)
+
+        await page.waitForURL('**/kvittering')
+
+        const readMore = page.getByRole('button', { name: 'Om din rett til å søke om sykepenger' })
+        await expect(readMore).toBeVisible()
+        await readMore.click()
+
+        await expect(
+            page.getByText(
+                'Du har ikke lenger mulighet til å søke med denne sykmeldingen, da den er eldre enn 4 måneder',
+            ),
+        ).toBeVisible()
+        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
     })
 })

--- a/playwright/sykmelding/optIn.spec.tsx
+++ b/playwright/sykmelding/optIn.spec.tsx
@@ -9,6 +9,26 @@ import {
 } from '../utils/user-actions'
 
 test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
+    let mottattTidspunktForTest: string
+
+    test.beforeEach(async ({ page }) => {
+        mottattTidspunktForTest = new Date().toISOString()
+
+        await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/id-apen-sykmelding', async (route) => {
+            if (route.request().method() === 'GET') {
+                const response = await route.fetch()
+                const json = await response.json()
+                json.mottattTidspunkt = mottattTidspunktForTest
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify(json),
+                })
+            }
+            return route.continue()
+        })
+    })
+
     test('viser opt-in-knapp når ingen søknad finnes', async ({ page }) => {
         await gotoScenario('normal', {
             erForsteSykmelding: false,
@@ -149,19 +169,7 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
     })
 
     test('viser varsel når sykmeldingen er eldre enn 4 måneder', async ({ page }) => {
-        await page.route('**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/id-apen-sykmelding', async (route) => {
-            if (route.request().method() === 'GET') {
-                const response = await route.fetch()
-                const json = await response.json()
-                json.sykmeldingStatus.timestamp = new Date('2025-01-01').toISOString()
-                return route.fulfill({
-                    status: 200,
-                    contentType: 'application/json',
-                    body: JSON.stringify(json),
-                })
-            }
-            return route.continue()
-        })
+        mottattTidspunktForTest = new Date('2025-01-01').toISOString()
 
         await gotoScenario('normal', {
             erForsteSykmelding: false,

--- a/playwright/sykmelding/optIn.spec.tsx
+++ b/playwright/sykmelding/optIn.spec.tsx
@@ -186,11 +186,7 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
         await expect(readMore).toBeVisible()
         await readMore.click()
 
-        await expect(
-            page.getByText(
-                'Du har ikke lenger mulighet til å søke med denne sykmeldingen, da den er eldre enn 4 måneder',
-            ),
-        ).toBeVisible()
+        await expect(page.getByText('Søknadsfristen er gått ut')).toBeVisible()
         await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
     })
 })

--- a/playwright/sykmelding/ventetid-opt-in.spec.ts
+++ b/playwright/sykmelding/ventetid-opt-in.spec.ts
@@ -1,7 +1,6 @@
-import { expect } from '@playwright/test'
+import { expect, test } from '../utils/fixtures'
 
 import { gotoScenario } from '../utils/user-actions'
-import { test } from '../utils/fixtures'
 
 const VENTETID_HEADING = 'Hva skjer videre?'
 const OPT_IN_READ_MORE = 'Om din rett til å søke om sykepenger'

--- a/playwright/sykmelding/ventetid-opt-in.spec.ts
+++ b/playwright/sykmelding/ventetid-opt-in.spec.ts
@@ -1,24 +1,26 @@
 import { expect, test } from '../utils/fixtures'
-
 import { gotoScenario } from '../utils/user-actions'
+import { apneReadmore, harSynligOverskrift, harSynligTekst } from '../utils/test-utils'
+import { validerAxe } from '../utils/uuvalidering'
 
 const VENTETID_HEADING = 'Hva skjer videre?'
 const OPT_IN_READ_MORE = 'Om din rett til å søke om sykepenger'
 
 test.describe('Opt-in info vises kun for sykmeldinger innenfor ventetiden', () => {
     test.describe('Innsendt sykmelding (BEKREFTET frilanser)', () => {
-        test('viser opt-in info når sykmelding er innenfor ventetiden', async ({ page }) => {
+        test('viser opt-in info når sykmelding er innenfor ventetiden', async ({ page }, testInfo) => {
             await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: false })(page)
-
             await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
 
-            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).toBeVisible()
-            await expect(page.getByText(OPT_IN_READ_MORE)).toBeVisible()
+            await harSynligOverskrift(page, VENTETID_HEADING, 2)
+            await harSynligTekst(page, 'Hvis du er syk i mindre enn 16 dager')
+            await apneReadmore(page, OPT_IN_READ_MORE, ['Det er Nav som avgjør om du oppfyller vilkårene'])
+
+            await validerAxe(page, testInfo)
         })
 
         test('skjuler opt-in info når sykmelding er utenfor ventetiden', async ({ page }) => {
             await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: true })(page)
-
             await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
 
             await expect(page.getByRole('heading', { name: VENTETID_HEADING })).not.toBeVisible()
@@ -27,19 +29,20 @@ test.describe('Opt-in info vises kun for sykmeldinger innenfor ventetiden', () =
     })
 
     test.describe('Kvittering (frilanser)', () => {
-        test('viser opt-in info på kvittering når sykmelding er innenfor ventetiden', async ({ page }) => {
+        test('viser opt-in info på kvittering når sykmelding er innenfor ventetiden', async ({ page }, testInfo) => {
             await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: false })(page)
-
             await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
             await page.goto(page.url() + '/kvittering')
 
-            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).toBeVisible()
-            await expect(page.getByText(OPT_IN_READ_MORE)).toBeVisible()
+            await harSynligOverskrift(page, VENTETID_HEADING, 2)
+            await harSynligTekst(page, 'Hvis du er syk i mindre enn 16 dager')
+            await apneReadmore(page, OPT_IN_READ_MORE, ['Det er Nav som avgjør om du oppfyller vilkårene'])
+
+            await validerAxe(page, testInfo)
         })
 
         test('skjuler opt-in info på kvittering når sykmelding er utenfor ventetiden', async ({ page }) => {
             await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: true })(page)
-
             await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
             await page.goto(page.url() + '/kvittering')
 

--- a/playwright/sykmelding/ventetid-opt-in.spec.ts
+++ b/playwright/sykmelding/ventetid-opt-in.spec.ts
@@ -1,0 +1,51 @@
+import { expect } from '@playwright/test'
+
+import { gotoScenario } from '../utils/user-actions'
+import { test } from '../utils/fixtures'
+
+const VENTETID_HEADING = 'Hva skjer videre?'
+const OPT_IN_READ_MORE = 'Om din rett til å søke om sykepenger'
+
+test.describe('Opt-in info vises kun for sykmeldinger innenfor ventetiden', () => {
+    test.describe('Innsendt sykmelding (BEKREFTET frilanser)', () => {
+        test('viser opt-in info når sykmelding er innenfor ventetiden', async ({ page }) => {
+            await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: false })(page)
+
+            await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
+
+            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).toBeVisible()
+            await expect(page.getByText(OPT_IN_READ_MORE)).toBeVisible()
+        })
+
+        test('skjuler opt-in info når sykmelding er utenfor ventetiden', async ({ page }) => {
+            await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: true })(page)
+
+            await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
+
+            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).not.toBeVisible()
+            await expect(page.getByText(OPT_IN_READ_MORE)).not.toBeVisible()
+        })
+    })
+
+    test.describe('Kvittering (frilanser)', () => {
+        test('viser opt-in info på kvittering når sykmelding er innenfor ventetiden', async ({ page }) => {
+            await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: false })(page)
+
+            await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
+            await page.goto(page.url() + '/kvittering')
+
+            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).toBeVisible()
+            await expect(page.getByText(OPT_IN_READ_MORE)).toBeVisible()
+        })
+
+        test('skjuler opt-in info på kvittering når sykmelding er utenfor ventetiden', async ({ page }) => {
+            await gotoScenario('bekreftetFrilanser', { erUtenforVentetid: true })(page)
+
+            await page.getByRole('region', { name: /Tidligere sykmeldinger/i }).getByRole('link').first().click()
+            await page.goto(page.url() + '/kvittering')
+
+            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).not.toBeVisible()
+            await expect(page.getByText(OPT_IN_READ_MORE)).not.toBeVisible()
+        })
+    })
+})

--- a/src/components/SykmeldingVentetid/OptIn.tsx
+++ b/src/components/SykmeldingVentetid/OptIn.tsx
@@ -4,7 +4,15 @@ import { Alert, Button, Skeleton } from '@navikt/ds-react'
 import useHarSoknad from '../../hooks/sykmelding/useHarSoknad'
 import useOptIn from '../../hooks/sykmelding/useOptIn'
 
-export function OptIn({ sykmeldingId, enabled }: { sykmeldingId: string; enabled: boolean }): ReactElement {
+export function OptIn({
+    sykmeldingId,
+    enabled,
+    onOptInSuccess,
+}: {
+    sykmeldingId: string
+    enabled: boolean
+    onOptInSuccess?: () => void
+}): ReactElement {
     const {
         data: harSoknadData,
         isLoading: harSoknadLoading,
@@ -33,7 +41,12 @@ export function OptIn({ sykmeldingId, enabled }: { sykmeldingId: string; enabled
     }
 
     return (
-        <Button variant="secondary-neutral" size="small" loading={optInPending} onClick={() => optIn()}>
+        <Button
+            variant="secondary-neutral"
+            size="small"
+            loading={optInPending}
+            onClick={() => optIn(undefined, { onSuccess: onOptInSuccess })}
+        >
             Jeg vil søke om sykepenger
         </Button>
     )

--- a/src/components/SykmeldingVentetid/OptIn.tsx
+++ b/src/components/SykmeldingVentetid/OptIn.tsx
@@ -1,0 +1,40 @@
+import { ReactElement } from 'react'
+import { Alert, Button, Skeleton } from '@navikt/ds-react'
+
+import useHarSoknad from '../../hooks/sykmelding/useHarSoknad'
+import useOptIn from '../../hooks/sykmelding/useOptIn'
+
+export function OptIn({ sykmeldingId, enabled }: { sykmeldingId: string; enabled: boolean }): ReactElement {
+    const {
+        data: harSoknadData,
+        isLoading: harSoknadLoading,
+        isError: harSoknadError,
+    } = useHarSoknad(sykmeldingId, enabled)
+    const { mutate: optIn, isPending: optInPending, isError: optInError } = useOptIn(sykmeldingId)
+
+    if (harSoknadLoading) {
+        return <Skeleton width="100%" />
+    }
+
+    if (harSoknadError || optInError) {
+        return (
+            <Alert variant="error" className="mt-4" size="small">
+                Beklager, en feil oppstod. Vennligst prøv igjen senere.
+            </Alert>
+        )
+    }
+
+    if (harSoknadData?.harSoknad) {
+        return (
+            <Alert variant="info" className="mt-4" role="alert" aria-live="polite" size="small">
+                Du har en søknad for denne perioden.
+            </Alert>
+        )
+    }
+
+    return (
+        <Button variant="secondary-neutral" size="small" loading={optInPending} onClick={() => optIn()}>
+            Jeg vil søke om sykepenger
+        </Button>
+    )
+}

--- a/src/components/SykmeldingVentetid/OptInSuksessAlert.tsx
+++ b/src/components/SykmeldingVentetid/OptInSuksessAlert.tsx
@@ -1,0 +1,16 @@
+import { ReactElement } from 'react'
+import { Alert, BodyShort, Heading } from '@navikt/ds-react'
+
+export function OptInSuksessAlert(): ReactElement {
+    return (
+        <Alert variant="info" role="status">
+            <Heading size="small" level="3" spacing>
+                Vi oppretter søknad etter sykmeldingsperioden er over
+            </Heading>
+            <BodyShort>
+                Du vil få beskjed av oss når du skal fylle ut og sende inn søknaden om sykepenger for
+                sykmeldingsperioden.
+            </BodyShort>
+        </Alert>
+    )
+}

--- a/src/components/SykmeldingVentetid/VentetidInfo.test.tsx
+++ b/src/components/SykmeldingVentetid/VentetidInfo.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { VentetidInfo } from './VentetidInfo'
+
+const { OptInMock } = vi.hoisted(() => ({
+    OptInMock: ({ sykmeldingId }: { sykmeldingId: string }) => <div data-testid="opt-in">{sykmeldingId}</div>,
+}))
+
+vi.mock('./OptIn', () => ({ OptIn: OptInMock }))
+
+describe('VentetidInfo', () => {
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('viser opt-in når sykmeldingen er innenfor fire måneder og én dag', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-05-29T12:00:00.000Z'))
+
+        render(<VentetidInfo sykmeldingId="123" optInFrist={new Date('2026-05-30T00:00:00.000Z')} />)
+
+        screen.getByTestId('opt-in')
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('viser informasjonsvarsel når fristen på fire måneder og én dag er passert', () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2026-05-29T12:00:00.000Z'))
+
+        render(<VentetidInfo sykmeldingId="123" optInFrist={new Date('2026-05-28T00:00:00.000Z')} />)
+
+        expect(screen.getByText('Søknadsfristen er gått ut.')).toBeInTheDocument()
+        expect(screen.queryByTestId('opt-in')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/SykmeldingVentetid/VentetidInfo.tsx
+++ b/src/components/SykmeldingVentetid/VentetidInfo.tsx
@@ -7,7 +7,15 @@ import { tilLesbarDatoMedArstall } from '../../utils/dato-utils'
 
 import { OptIn } from './OptIn'
 
-export function VentetidInfo({ sykmeldingId, optInFrist }: { sykmeldingId: string; optInFrist: Date }): ReactElement {
+export function VentetidInfo({
+    sykmeldingId,
+    optInFrist,
+    onOptInSuccess,
+}: {
+    sykmeldingId: string
+    optInFrist: Date
+    onOptInSuccess?: () => void
+}): ReactElement {
     const [open, setOpen] = useState(false)
     const sykmeldingNyereEnn4Mnd = isAfter(optInFrist, new Date())
 
@@ -43,7 +51,7 @@ export function VentetidInfo({ sykmeldingId, optInFrist }: { sykmeldingId: strin
                 <BodyShort spacing>Da må du søke innen {tilLesbarDatoMedArstall(optInFrist)}.</BodyShort>
                 <BodyShort spacing>Da sender vi deg en søknad når sykmeldingsperioden er over.</BodyShort>
                 {sykmeldingNyereEnn4Mnd ? (
-                    <OptIn sykmeldingId={sykmeldingId} enabled={open} />
+                    <OptIn sykmeldingId={sykmeldingId} enabled={open} onOptInSuccess={onOptInSuccess} />
                 ) : (
                     <Alert variant="info">
                         <Heading size="small" level="3" spacing>

--- a/src/components/SykmeldingVentetid/VentetidInfo.tsx
+++ b/src/components/SykmeldingVentetid/VentetidInfo.tsx
@@ -1,18 +1,15 @@
 import { ReactElement, useState } from 'react'
 import { Alert, BodyShort, Heading, ReadMore } from '@navikt/ds-react'
+import { isAfter } from 'date-fns'
 
 import { LenkeMedIkon } from '../lenke/lenke-med-ikon'
+import { tilLesbarDatoMedArstall } from '../../utils/dato-utils'
 
 import { OptIn } from './OptIn'
 
-export function VentetidInfo({
-    sykmeldingId,
-    sykmeldingNyereEnn4Mnd,
-}: {
-    sykmeldingId: string
-    sykmeldingNyereEnn4Mnd?: boolean
-}): ReactElement {
+export function VentetidInfo({ sykmeldingId, optInFrist }: { sykmeldingId: string; optInFrist: Date }): ReactElement {
     const [open, setOpen] = useState(false)
+    const sykmeldingNyereEnn4Mnd = isAfter(optInFrist, new Date())
 
     return (
         <>
@@ -39,16 +36,20 @@ export function VentetidInfo({
                 <BodyShort className="mt-4" weight="semibold" spacing>
                     Vil du søke om sykepenger?
                 </BodyShort>
-                <BodyShort spacing>
+                <BodyShort>
                     Hvis du mener du har rett på sykepenger for denne sykmeldingsperioden og du vil søke om sykepenger,
                     har du rett til det.
                 </BodyShort>
+                <BodyShort spacing>Da må du søke innen {tilLesbarDatoMedArstall(optInFrist)}.</BodyShort>
                 <BodyShort spacing>Da sender vi deg en søknad når sykmeldingsperioden er over.</BodyShort>
                 {sykmeldingNyereEnn4Mnd ? (
                     <OptIn sykmeldingId={sykmeldingId} enabled={open} />
                 ) : (
                     <Alert variant="info">
-                        Du har ikke lenger mulighet til å søke med denne sykmeldingen, da den er eldre enn 4 måneder
+                        <Heading size="small" level="3" spacing>
+                            Søknadsfristen er gått ut.
+                        </Heading>
+                        Hvis du mener det har skjedd en feil, kan du kontakte Nav for å få hjelp.
                     </Alert>
                 )}
             </ReadMore>

--- a/src/components/SykmeldingVentetid/VentetidInfo.tsx
+++ b/src/components/SykmeldingVentetid/VentetidInfo.tsx
@@ -1,11 +1,17 @@
 import { ReactElement, useState } from 'react'
-import { BodyShort, Heading, ReadMore } from '@navikt/ds-react'
+import { Alert, BodyShort, Heading, ReadMore } from '@navikt/ds-react'
 
 import { LenkeMedIkon } from '../lenke/lenke-med-ikon'
 
 import { OptIn } from './OptIn'
 
-export function VentetidInfo({ sykmeldingId }: { sykmeldingId: string }): ReactElement {
+export function VentetidInfo({
+    sykmeldingId,
+    sykmeldingNyereEnn4Mnd,
+}: {
+    sykmeldingId: string
+    sykmeldingNyereEnn4Mnd?: boolean
+}): ReactElement {
     const [open, setOpen] = useState(false)
 
     return (
@@ -38,7 +44,13 @@ export function VentetidInfo({ sykmeldingId }: { sykmeldingId: string }): ReactE
                     har du rett til det.
                 </BodyShort>
                 <BodyShort spacing>Da sender vi deg en søknad når sykmeldingsperioden er over.</BodyShort>
-                <OptIn sykmeldingId={sykmeldingId} enabled={open} />
+                {sykmeldingNyereEnn4Mnd ? (
+                    <OptIn sykmeldingId={sykmeldingId} enabled={open} />
+                ) : (
+                    <Alert variant="info">
+                        Du har ikke lenger mulighet til å søke med denne sykmeldingen, da den er eldre enn 4 måneder
+                    </Alert>
+                )}
             </ReadMore>
             <BodyShort className="mt-6" weight="semibold" spacing>
                 Hvis du er syk i mer enn 16 dager

--- a/src/components/SykmeldingVentetid/VentetidInfo.tsx
+++ b/src/components/SykmeldingVentetid/VentetidInfo.tsx
@@ -1,0 +1,53 @@
+import { ReactElement, useState } from 'react'
+import { BodyShort, Heading, ReadMore } from '@navikt/ds-react'
+
+import { LenkeMedIkon } from '../lenke/lenke-med-ikon'
+
+import { OptIn } from './OptIn'
+
+export function VentetidInfo({ sykmeldingId }: { sykmeldingId: string }): ReactElement {
+    const [open, setOpen] = useState(false)
+
+    return (
+        <>
+            <Heading size="medium" level="2" spacing>
+                Hva skjer videre?
+            </Heading>
+            <BodyShort className="mt-6" weight="semibold" spacing>
+                Hvis du er syk i mindre enn 16 dager
+            </BodyShort>
+            <BodyShort spacing>
+                Du får som hovedregel ikke sykepenger de første 16 kalenderdagene. Dagene telles fra du oppsøker lege,
+                eller fra Nav får beskjed om at du er syk og ikke kan jobbe.
+            </BodyShort>
+            <ReadMore
+                header="Om din rett til å søke om sykepenger"
+                className="mt-4"
+                open={open}
+                onClick={() => setOpen(!open)}
+            >
+                <BodyShort spacing>
+                    Det er Nav som avgjør om du oppfyller vilkårene for å få sykepenger eller ei, men alle har rett til
+                    å søke.
+                </BodyShort>
+                <BodyShort className="mt-4" weight="semibold" spacing>
+                    Vil du søke om sykepenger?
+                </BodyShort>
+                <BodyShort spacing>
+                    Hvis du mener du har rett på sykepenger for denne sykmeldingsperioden og du vil søke om sykepenger,
+                    har du rett til det.
+                </BodyShort>
+                <BodyShort spacing>Da sender vi deg en søknad når sykmeldingsperioden er over.</BodyShort>
+                <OptIn sykmeldingId={sykmeldingId} enabled={open} />
+            </ReadMore>
+            <BodyShort className="mt-6" weight="semibold" spacing>
+                Hvis du er syk i mer enn 16 dager
+            </BodyShort>
+            <BodyShort spacing>
+                Varer sykefraværet ditt mer enn 16 dager, dekker Nav sykepengene dine fra dag 17. Vi gir deg beskjed når
+                du kan søke om sykepenger.
+            </BodyShort>
+            <LenkeMedIkon href="https://www.nav.no/sykepenger#hva" text="Les mer om hva du kan få i sykepenger." />
+        </>
+    )
+}

--- a/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -3,7 +3,7 @@ import { Button } from '@navikt/ds-react'
 import { PencilWritingIcon } from '@navikt/aksel-icons'
 
 import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
-import { isSykmeldingNyereEnnFireMaaneder } from '../../../../utils/sykmeldingUtils'
+import { finnOptInFrist } from '../../../../utils/sykmeldingUtils'
 import StatusBanner from '../../../StatusBanner/StatusBanner'
 import SykmeldingSykmeldtSection from '../../../Sykmelding/SykmeldingerSykmeldt/SykmeldingSykmeldtSection'
 import { ArbeidssituasjonType } from '../../../../types/sykmelding/sykmeldingCommon'
@@ -15,7 +15,7 @@ interface OkBekreftetSykmeldingProps {
 }
 
 function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProps): ReactElement {
-    const sykmeldingNyereEnn4Mnd = isSykmeldingNyereEnnFireMaaneder(sykmelding)
+    const optInFrist = finnOptInFrist(sykmelding)
     return (
         <div className="sykmelding-container">
             <div className="mb-4">
@@ -46,7 +46,7 @@ function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProp
             {(sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.NAERINGSDRIVENDE ||
                 sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.FRILANSER) && (
                 <div className="mb-8">
-                    <VentetidInfo sykmeldingId={sykmelding.id} sykmeldingNyereEnn4Mnd={sykmeldingNyereEnn4Mnd} />
+                    <VentetidInfo sykmeldingId={sykmelding.id} optInFrist={optInFrist} />
                 </div>
             )}
 

--- a/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -1,5 +1,5 @@
-import React, { ReactElement } from 'react'
-import { Button } from '@navikt/ds-react'
+import React, { ReactElement, useState } from 'react'
+import { Alert, BodyShort, Button, Heading } from '@navikt/ds-react'
 import { PencilWritingIcon } from '@navikt/aksel-icons'
 
 import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
@@ -15,9 +15,23 @@ interface OkBekreftetSykmeldingProps {
 }
 
 function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProps): ReactElement {
+    const [optInSuksess, setOptInSuksess] = useState(false)
     const optInFrist = finnOptInFrist(sykmelding)
     return (
         <div className="sykmelding-container">
+            {optInSuksess && (
+                <div className="mb-4">
+                    <Alert variant="info" role="status">
+                        <Heading size="small" level="3" spacing>
+                            Vi oppretter søknad etter sykmeldingsperioden er over
+                        </Heading>
+                        <BodyShort>
+                            Du vil få beskjed av oss når du skal fylle ut og sende inn søknaden om sykepenger for
+                            sykmeldingsperioden.
+                        </BodyShort>
+                    </Alert>
+                </div>
+            )}
             <div className="mb-4">
                 <StatusBanner
                     sykmeldingStatus={sykmelding.sykmeldingStatus}
@@ -46,7 +60,11 @@ function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProp
             {(sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.NAERINGSDRIVENDE ||
                 sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.FRILANSER) && (
                 <div className="mb-8">
-                    <VentetidInfo sykmeldingId={sykmelding.id} optInFrist={optInFrist} />
+                    <VentetidInfo
+                        sykmeldingId={sykmelding.id}
+                        optInFrist={optInFrist}
+                        onOptInSuccess={() => setOptInSuksess(true)}
+                    />
                 </div>
             )}
 

--- a/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -9,6 +9,7 @@ import SykmeldingSykmeldtSection from '../../../Sykmelding/SykmeldingerSykmeldt/
 import { ArbeidssituasjonType } from '../../../../types/sykmelding/sykmeldingCommon'
 import { VentetidInfo } from '../../../SykmeldingVentetid/VentetidInfo'
 import { OptInSuksessAlert } from '../../../SykmeldingVentetid/OptInSuksessAlert'
+import useErUtenforVentetid from '../../../../hooks/sykmelding/useErUtenforVentetid'
 
 interface OkBekreftetSykmeldingProps {
     sykmelding: Sykmelding
@@ -18,6 +19,12 @@ interface OkBekreftetSykmeldingProps {
 function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProps): ReactElement {
     const [optInSuksess, setOptInSuksess] = useState(false)
     const optInFrist = finnOptInFrist(sykmelding)
+
+    const erNaeringsdrivendeEllerFrilanser =
+        sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.NAERINGSDRIVENDE ||
+        sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.FRILANSER
+
+    const { data: utenforVentetidData } = useErUtenforVentetid(sykmelding.id, erNaeringsdrivendeEllerFrilanser)
     return (
         <div className="sykmelding-container">
             {optInSuksess && (
@@ -50,8 +57,7 @@ function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProp
                 </div>
             )}
 
-            {(sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.NAERINGSDRIVENDE ||
-                sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.FRILANSER) && (
+            {erNaeringsdrivendeEllerFrilanser && utenforVentetidData?.erUtenforVentetid === false && (
                 <div className="mb-8">
                     <VentetidInfo
                         sykmeldingId={sykmelding.id}

--- a/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -1,10 +1,12 @@
-import { ReactElement } from 'react'
+import React, { ReactElement } from 'react'
 import { Button } from '@navikt/ds-react'
 import { PencilWritingIcon } from '@navikt/aksel-icons'
 
 import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
 import StatusBanner from '../../../StatusBanner/StatusBanner'
 import SykmeldingSykmeldtSection from '../../../Sykmelding/SykmeldingerSykmeldt/SykmeldingSykmeldtSection'
+import { ArbeidssituasjonType } from '../../../../types/sykmelding/sykmeldingCommon'
+import { VentetidInfo } from '../../../SykmeldingVentetid/VentetidInfo'
 
 interface OkBekreftetSykmeldingProps {
     sykmelding: Sykmelding
@@ -36,6 +38,13 @@ function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProp
                             GJØR UTFYLLINGEN PÅ NYTT
                         </Button>
                     </div>
+                </div>
+            )}
+
+            {(sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.NAERINGSDRIVENDE ||
+                sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.FRILANSER) && (
+                <div className="mb-8">
+                    <VentetidInfo sykmeldingId={sykmelding.id} />
                 </div>
             )}
 

--- a/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from 'react'
-import { Alert, BodyShort, Button, Heading } from '@navikt/ds-react'
+import { Button } from '@navikt/ds-react'
 import { PencilWritingIcon } from '@navikt/aksel-icons'
 
 import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
@@ -8,6 +8,7 @@ import StatusBanner from '../../../StatusBanner/StatusBanner'
 import SykmeldingSykmeldtSection from '../../../Sykmelding/SykmeldingerSykmeldt/SykmeldingSykmeldtSection'
 import { ArbeidssituasjonType } from '../../../../types/sykmelding/sykmeldingCommon'
 import { VentetidInfo } from '../../../SykmeldingVentetid/VentetidInfo'
+import { OptInSuksessAlert } from '../../../SykmeldingVentetid/OptInSuksessAlert'
 
 interface OkBekreftetSykmeldingProps {
     sykmelding: Sykmelding
@@ -21,15 +22,7 @@ function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProp
         <div className="sykmelding-container">
             {optInSuksess && (
                 <div className="mb-4">
-                    <Alert variant="info" role="status">
-                        <Heading size="small" level="3" spacing>
-                            Vi oppretter søknad etter sykmeldingsperioden er over
-                        </Heading>
-                        <BodyShort>
-                            Du vil få beskjed av oss når du skal fylle ut og sende inn søknaden om sykepenger for
-                            sykmeldingsperioden.
-                        </BodyShort>
-                    </Alert>
+                    <OptInSuksessAlert />
                 </div>
             )}
             <div className="mb-4">

--- a/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react'
 import { Button } from '@navikt/ds-react'
 import { PencilWritingIcon } from '@navikt/aksel-icons'
+import dayjs from 'dayjs'
 
 import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
 import StatusBanner from '../../../StatusBanner/StatusBanner'
@@ -14,6 +15,9 @@ interface OkBekreftetSykmeldingProps {
 }
 
 function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProps): ReactElement {
+    const sykmeldingNyereEnn4Mnd =
+        sykmelding.sykmeldingStatus.timestamp != null &&
+        dayjs(sykmelding.sykmeldingStatus.timestamp).isAfter(dayjs().subtract(4, 'months'))
     return (
         <div className="sykmelding-container">
             <div className="mb-4">
@@ -44,7 +48,7 @@ function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProp
             {(sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.NAERINGSDRIVENDE ||
                 sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.FRILANSER) && (
                 <div className="mb-8">
-                    <VentetidInfo sykmeldingId={sykmelding.id} />
+                    <VentetidInfo sykmeldingId={sykmelding.id} sykmeldingNyereEnn4Mnd={sykmeldingNyereEnn4Mnd} />
                 </div>
             )}
 

--- a/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -6,10 +6,9 @@ import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
 import { finnOptInFrist } from '../../../../utils/sykmeldingUtils'
 import StatusBanner from '../../../StatusBanner/StatusBanner'
 import SykmeldingSykmeldtSection from '../../../Sykmelding/SykmeldingerSykmeldt/SykmeldingSykmeldtSection'
-import { ArbeidssituasjonType } from '../../../../types/sykmelding/sykmeldingCommon'
 import { VentetidInfo } from '../../../SykmeldingVentetid/VentetidInfo'
 import { OptInSuksessAlert } from '../../../SykmeldingVentetid/OptInSuksessAlert'
-import useErUtenforVentetid from '../../../../hooks/sykmelding/useErUtenforVentetid'
+import { useVisVentetidInfo } from '../../../../hooks/sykmelding/useVisVentetidInfo'
 
 interface OkBekreftetSykmeldingProps {
     sykmelding: Sykmelding
@@ -19,12 +18,10 @@ interface OkBekreftetSykmeldingProps {
 function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProps): ReactElement {
     const [optInSuksess, setOptInSuksess] = useState(false)
     const optInFrist = finnOptInFrist(sykmelding)
-
-    const erNaeringsdrivendeEllerFrilanser =
-        sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.NAERINGSDRIVENDE ||
-        sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar === ArbeidssituasjonType.FRILANSER
-
-    const { data: utenforVentetidData } = useErUtenforVentetid(sykmelding.id, erNaeringsdrivendeEllerFrilanser)
+    const visVentetidInfo = useVisVentetidInfo(
+        sykmelding.id,
+        sykmelding.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar,
+    )
     return (
         <div className="sykmelding-container">
             {optInSuksess && (
@@ -57,7 +54,7 @@ function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProp
                 </div>
             )}
 
-            {erNaeringsdrivendeEllerFrilanser && utenforVentetidData?.erUtenforVentetid === false && (
+            {visVentetidInfo && (
                 <div className="mb-8">
                     <VentetidInfo
                         sykmeldingId={sykmelding.id}

--- a/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/BEKREFTET/OkBekreftetSykmelding.tsx
@@ -1,9 +1,9 @@
 import React, { ReactElement } from 'react'
 import { Button } from '@navikt/ds-react'
 import { PencilWritingIcon } from '@navikt/aksel-icons'
-import dayjs from 'dayjs'
 
 import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
+import { isSykmeldingNyereEnnFireMaaneder } from '../../../../utils/sykmeldingUtils'
 import StatusBanner from '../../../StatusBanner/StatusBanner'
 import SykmeldingSykmeldtSection from '../../../Sykmelding/SykmeldingerSykmeldt/SykmeldingSykmeldtSection'
 import { ArbeidssituasjonType } from '../../../../types/sykmelding/sykmeldingCommon'
@@ -15,9 +15,7 @@ interface OkBekreftetSykmeldingProps {
 }
 
 function OkBekreftetSykmelding({ sykmelding, reopen }: OkBekreftetSykmeldingProps): ReactElement {
-    const sykmeldingNyereEnn4Mnd =
-        sykmelding.sykmeldingStatus.timestamp != null &&
-        dayjs(sykmelding.sykmeldingStatus.timestamp).isAfter(dayjs().subtract(4, 'months'))
+    const sykmeldingNyereEnn4Mnd = isSykmeldingNyereEnnFireMaaneder(sykmelding)
     return (
         <div className="sykmelding-container">
             <div className="mb-4">

--- a/src/data/mock/mock-api.ts
+++ b/src/data/mock/mock-api.ts
@@ -154,6 +154,12 @@ export async function mockApi(req: NextApiRequest, res: NextApiResponse): Promis
             const body = await parseRequest<SykmeldingChangeStatus>(req)
             return sendJson(mockDb().get(sessionId).changeSykmeldingStatus(params.uuid, body))
         },
+        'GET /api/flex-sykmeldinger-backend/api/v1/sykmeldinger/:uuid/har-soknad': (params) => {
+            return sendJson(mockDb().get(sessionId).harSoknad(params.uuid))
+        },
+        'POST /api/flex-sykmeldinger-backend/api/v1/sykmeldinger/:uuid/opt-in': (params) => {
+            return sendJson(mockDb().get(sessionId).optIn(params.uuid))
+        },
         'GET /api/sykepengedager-informasjon/api/v1/sykepenger/maxdate': () => {
             return sendJson(testperson.maxdato)
         },

--- a/src/data/mock/mock-db/MockDb.ts
+++ b/src/data/mock/mock-db/MockDb.ts
@@ -100,6 +100,7 @@ class MockDb {
             )
 
             sykmelding.sykmeldingStatus.statusEvent = StatusEvent.SENDT
+            sykmelding.sykmeldingStatus.timestamp = new Date().toISOString()
             sykmelding.sykmeldingStatus.arbeidsgiver = selectedArbeidsgiver
                 ? {
                       orgnummer: selectedArbeidsgiver.orgnummer,
@@ -108,6 +109,7 @@ class MockDb {
                 : null
         } else {
             sykmelding.sykmeldingStatus.statusEvent = StatusEvent.BEKREFTET
+            sykmelding.sykmeldingStatus.timestamp = new Date().toISOString()
         }
 
         sykmelding.sykmeldingStatus.brukerSvar = apiValues as unknown as BrukerSvar

--- a/src/data/mock/mock-db/MockDb.ts
+++ b/src/data/mock/mock-db/MockDb.ts
@@ -16,6 +16,7 @@ class MockDb {
     private _antallArbeidsgivere = 1
     private _erForsteSykmelding = true
     private _erUtenforVentetid = false
+    private _optedInSykmeldinger: Set<string> = new Set()
 
     constructor(scenario: { sykmeldinger: MuterbarSykmelding[] }) {
         this._sykmeldinger = scenario.sykmeldinger
@@ -124,6 +125,15 @@ class MockDb {
 
     setErUtenforVentetid(erUtenforVentetid: boolean): void {
         this._erUtenforVentetid = erUtenforVentetid
+    }
+
+    harSoknad(sykmeldingId: string): { harSoknad: boolean } {
+        return { harSoknad: this._optedInSykmeldinger.has(sykmeldingId) }
+    }
+
+    optIn(sykmeldingId: string): { status: string } {
+        this._optedInSykmeldinger.add(sykmeldingId)
+        return { status: 'ok' }
     }
 
     private arbeidsgivere(): Arbeidsgiver[] {

--- a/src/data/mock/mock-db/data-creators.ts
+++ b/src/data/mock/mock-db/data-creators.ts
@@ -216,7 +216,9 @@ export class SykmeldingBuilder {
     bekreft(
         arbeidssituasjon:
             | ArbeidssituasjonType.ANNET
-            | ArbeidssituasjonType.ARBEIDSLEDIG = ArbeidssituasjonType.ARBEIDSLEDIG,
+            | ArbeidssituasjonType.ARBEIDSLEDIG
+            | ArbeidssituasjonType.NAERINGSDRIVENDE
+            | ArbeidssituasjonType.FRILANSER = ArbeidssituasjonType.ARBEIDSLEDIG,
     ): SykmeldingBuilder {
         this._sykmelding.sykmeldingStatus.statusEvent = StatusEvent.BEKREFTET
         this._sykmelding.sykmeldingStatus.timestamp = this.mottatt

--- a/src/data/mock/mock-db/scenarios.ts
+++ b/src/data/mock/mock-db/scenarios.ts
@@ -1,5 +1,6 @@
 import { Merknadtype, Periodetype, RegelStatus, StatusEvent } from '../../../types/sykmelding/sykmelding'
 import { MuterbarSykmelding } from '../../../server/api-models/sykmelding/MuterbarSykmelding'
+import { ArbeidssituasjonType } from '../../../types/sykmelding/sykmeldingCommon'
 
 import { SykmeldingBuilder } from './data-creators'
 
@@ -605,6 +606,17 @@ export const e2eScenarios = {
                     )
                     .build(),
                 new SykmeldingBuilder(-14).bekreft().enkelPeriode({ offset: 0, days: 12 }).build(),
+            ],
+        }),
+    },
+    bekreftetFrilanser: {
+        description: 'En bekreftet sykmelding for frilanser (brukes for ventetid-tester)',
+        scenario: () => ({
+            sykmeldinger: [
+                new SykmeldingBuilder(-14, 'id-bekreftet-frilanser')
+                    .bekreft(ArbeidssituasjonType.FRILANSER)
+                    .enkelPeriode({ offset: 0, days: 10 })
+                    .build(),
             ],
         }),
     },

--- a/src/hooks/sykmelding/useErUtenforVentetid.ts
+++ b/src/hooks/sykmelding/useErUtenforVentetid.ts
@@ -3,11 +3,12 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchJsonMedRequestId } from '../../utils/fetch'
 import { UseTestpersonQuery } from '../useTestpersonQuery'
 
-export default function useErUtenforVentetid(sykmeldingId: string) {
+export default function useErUtenforVentetid(sykmeldingId: string, enabled = true) {
     const testpersonQuery = UseTestpersonQuery()
 
     return useQuery<UtenforVentetid, Error>({
         queryKey: ['er-utenfor-ventetid', sykmeldingId],
+        enabled,
         queryFn: () =>
             fetchJsonMedRequestId(
                 '/syk/sykefravaer/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/' +

--- a/src/hooks/sykmelding/useHarSoknad.ts
+++ b/src/hooks/sykmelding/useHarSoknad.ts
@@ -1,0 +1,25 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query'
+
+import { fetchJsonMedRequestId } from '../../utils/fetch'
+import { UseTestpersonQuery } from '../useTestpersonQuery'
+
+interface HarSoknadResponse {
+    harSoknad: boolean
+}
+
+export default function useHarSoknad(sykmeldingId: string, enabled: boolean): UseQueryResult<HarSoknadResponse, Error> {
+    const testpersonQuery = UseTestpersonQuery()
+
+    return useQuery<HarSoknadResponse, Error>({
+        queryKey: ['har-soknad', sykmeldingId],
+        queryFn: async () => {
+            return fetchJsonMedRequestId(
+                '/syk/sykefravaer/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/' +
+                    sykmeldingId +
+                    '/har-soknad' +
+                    testpersonQuery.query(),
+            )
+        },
+        enabled,
+    })
+}

--- a/src/hooks/sykmelding/useOptIn.ts
+++ b/src/hooks/sykmelding/useOptIn.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { fetchJsonMedRequestId } from '../../utils/fetch'
+import { UseTestpersonQuery } from '../useTestpersonQuery'
+
+export default function useOptIn(sykmeldingId: string) {
+    const queryClient = useQueryClient()
+    const testpersonQuery = UseTestpersonQuery()
+
+    return useMutation<unknown, Error, void>({
+        mutationFn: async () => {
+            return fetchJsonMedRequestId(
+                '/syk/sykefravaer/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/' +
+                    sykmeldingId +
+                    '/opt-in' +
+                    testpersonQuery.query(),
+                {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                },
+            )
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: ['har-soknad', sykmeldingId],
+            })
+        },
+    })
+}

--- a/src/hooks/sykmelding/useOptIn.ts
+++ b/src/hooks/sykmelding/useOptIn.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
-import { fetchJsonMedRequestId } from '../../utils/fetch'
+import fetchMedRequestId from '../../utils/fetch'
 import { UseTestpersonQuery } from '../useTestpersonQuery'
 
 export default function useOptIn(sykmeldingId: string) {
@@ -9,7 +9,7 @@ export default function useOptIn(sykmeldingId: string) {
 
     return useMutation<unknown, Error, void>({
         mutationFn: async () => {
-            return fetchJsonMedRequestId(
+            return fetchMedRequestId(
                 '/syk/sykefravaer/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/' +
                     sykmeldingId +
                     '/opt-in' +

--- a/src/hooks/sykmelding/useVisVentetidInfo.ts
+++ b/src/hooks/sykmelding/useVisVentetidInfo.ts
@@ -1,0 +1,13 @@
+import { ArbeidssituasjonType } from '../../types/sykmelding/sykmeldingCommon'
+
+import useErUtenforVentetid from './useErUtenforVentetid'
+
+export function useVisVentetidInfo(sykmeldingId: string, arbeidssituasjon: ArbeidssituasjonType | undefined): boolean {
+    const erNaeringsdrivendeEllerFrilanser =
+        arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
+        arbeidssituasjon === ArbeidssituasjonType.FRILANSER
+
+    const { data } = useErUtenforVentetid(sykmeldingId, erNaeringsdrivendeEllerFrilanser)
+
+    return erNaeringsdrivendeEllerFrilanser && data?.erUtenforVentetid === false
+}

--- a/src/pages/api/flex-sykmeldinger-backend/[[...path]].ts
+++ b/src/pages/api/flex-sykmeldinger-backend/[[...path]].ts
@@ -18,6 +18,8 @@ const tillatteApier = [
     'GET /api/v1/sykmeldinger/[uuid]/er-forste-sykmelding/[arbeidssituasjon]',
     'GET /api/v1/sykmeldinger/[uuid]/brukerinformasjon',
     'GET /api/v1/sykmeldinger/[uuid]/tidligere-arbeidsgivere',
+    'GET /api/v1/sykmeldinger/[uuid]/har-soknad',
+    'POST /api/v1/sykmeldinger/[uuid]/opt-in',
 ]
 
 const handler = beskyttetApi(async (req: NextApiRequest, res: NextApiResponse) => {

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -25,6 +25,7 @@ import useSykmelding from '../../../hooks/sykmelding/useSykmelding'
 import { ArbeidssituasjonType } from '../../../types/sykmelding/sykmeldingCommon'
 import { VentetidInfo } from '../../../components/SykmeldingVentetid/VentetidInfo'
 import { OptInSuksessAlert } from '../../../components/SykmeldingVentetid/OptInSuksessAlert'
+import useErUtenforVentetid from '../../../hooks/sykmelding/useErUtenforVentetid'
 
 function SykmeldingkvitteringPage(): ReactElement {
     const sykmeldingId = useGetSykmeldingIdParam()
@@ -34,6 +35,14 @@ function SykmeldingkvitteringPage(): ReactElement {
     const [optInSuksess, setOptInSuksess] = useState(false)
 
     const arbeissituasjonSvar = { arbeidssituasjon: data?.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar }
+
+    const erNaeringsdrivendeEllerFrilanser =
+        arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
+        arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.FRILANSER
+
+    const { data: utenforVentetidData } = useErUtenforVentetid(sykmeldingId, erNaeringsdrivendeEllerFrilanser)
+
+
     if (isPending) {
         return (
             <KvitteringWrapper>
@@ -107,8 +116,7 @@ function SykmeldingkvitteringPage(): ReactElement {
                     isEgenmeldingsKvittering={router.query.egenmelding === 'true'}
                 />
             </div>
-            {(arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
-                arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.FRILANSER) && (
+            {erNaeringsdrivendeEllerFrilanser && utenforVentetidData?.erUtenforVentetid === false && (
                 <VentetidInfo
                     sykmeldingId={sykmeldingId}
                     optInFrist={optInFrist}

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -12,11 +12,7 @@ import StatusInfo from '../../../components/StatusInfo/StatusInfo'
 import useGetSykmeldingIdParam from '../../../hooks/useGetSykmeldingIdParam'
 import Header from '../../../components/Header/Header'
 import PageWrapper from '../../../components/PageWrapper/PageWrapper'
-import {
-    getReadableSykmeldingLength,
-    getSentSykmeldingTitle,
-    isSykmeldingNyereEnnFireMaaneder,
-} from '../../../utils/sykmeldingUtils'
+import { finnOptInFrist, getReadableSykmeldingLength, getSentSykmeldingTitle } from '../../../utils/sykmeldingUtils'
 import HintToNextOlderSykmelding from '../../../components/ForceOrder/HintToNextOlderSykmelding'
 import SykmeldingArbeidsgiverExpansionCard from '../../../components/Sykmelding/SykmeldingerArbeidsgiver/SykmeldingArbeidsgiverExpansionCard'
 import SykmeldingSykmeldtSection from '../../../components/Sykmelding/SykmeldingerSykmeldt/SykmeldingSykmeldtSection'
@@ -36,7 +32,6 @@ function SykmeldingkvitteringPage(): ReactElement {
     const flexjarToggle = useToggle('flexjar-sykmelding-kvittering')
 
     const arbeissituasjonSvar = { arbeidssituasjon: data?.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar }
-
     if (isPending) {
         return (
             <KvitteringWrapper>
@@ -46,7 +41,6 @@ function SykmeldingkvitteringPage(): ReactElement {
             </KvitteringWrapper>
         )
     }
-
     if (error) {
         return (
             <KvitteringWrapper>
@@ -56,7 +50,6 @@ function SykmeldingkvitteringPage(): ReactElement {
             </KvitteringWrapper>
         )
     }
-
     if (data == null) {
         logger.error(`Sykmelding with id ${sykmeldingId} is undefined`)
         return (
@@ -67,7 +60,6 @@ function SykmeldingkvitteringPage(): ReactElement {
             </KvitteringWrapper>
         )
     }
-
     if (
         data.behandlingsutfall.status === RegelStatus.INVALID ||
         ![StatusEvent.SENDT, StatusEvent.BEKREFTET].includes(data.sykmeldingStatus.statusEvent)
@@ -97,7 +89,7 @@ function SykmeldingkvitteringPage(): ReactElement {
         )
     }
 
-    const sykmeldingNyereEnn4Mnd = isSykmeldingNyereEnnFireMaaneder(data)
+    const optInFrist = finnOptInFrist(data)
 
     return (
         <KvitteringWrapper sykmelding={data}>
@@ -110,7 +102,7 @@ function SykmeldingkvitteringPage(): ReactElement {
             </div>
             {(arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
                 arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.FRILANSER) && (
-                <VentetidInfo sykmeldingId={sykmeldingId} sykmeldingNyereEnn4Mnd={sykmeldingNyereEnn4Mnd} />
+                <VentetidInfo sykmeldingId={sykmeldingId} optInFrist={optInFrist} />
             )}
             <div className="mb-8">
                 <StatusInfo

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -22,10 +22,9 @@ import { beskyttetSideUtenProps } from '../../../auth/beskyttetSide'
 import { Flexjar } from '../../../components/flexjar/flexjar'
 import { useToggle } from '../../../toggles/context'
 import useSykmelding from '../../../hooks/sykmelding/useSykmelding'
-import { ArbeidssituasjonType } from '../../../types/sykmelding/sykmeldingCommon'
 import { VentetidInfo } from '../../../components/SykmeldingVentetid/VentetidInfo'
 import { OptInSuksessAlert } from '../../../components/SykmeldingVentetid/OptInSuksessAlert'
-import useErUtenforVentetid from '../../../hooks/sykmelding/useErUtenforVentetid'
+import { useVisVentetidInfo } from '../../../hooks/sykmelding/useVisVentetidInfo'
 
 function SykmeldingkvitteringPage(): ReactElement {
     const sykmeldingId = useGetSykmeldingIdParam()
@@ -36,11 +35,7 @@ function SykmeldingkvitteringPage(): ReactElement {
 
     const arbeissituasjonSvar = { arbeidssituasjon: data?.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar }
 
-    const erNaeringsdrivendeEllerFrilanser =
-        arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
-        arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.FRILANSER
-
-    const { data: utenforVentetidData } = useErUtenforVentetid(sykmeldingId, erNaeringsdrivendeEllerFrilanser)
+    const visVentetidInfo = useVisVentetidInfo(sykmeldingId, arbeissituasjonSvar.arbeidssituasjon)
 
 
     if (isPending) {
@@ -116,7 +111,7 @@ function SykmeldingkvitteringPage(): ReactElement {
                     isEgenmeldingsKvittering={router.query.egenmelding === 'true'}
                 />
             </div>
-            {erNaeringsdrivendeEllerFrilanser && utenforVentetidData?.erUtenforVentetid === false && (
+            {visVentetidInfo && (
                 <VentetidInfo
                     sykmeldingId={sykmeldingId}
                     optInFrist={optInFrist}

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import React, { Fragment, PropsWithChildren, ReactElement } from 'react'
+import React, { Fragment, PropsWithChildren, ReactElement, useState } from 'react'
 import { Alert, BodyShort, GuidePanel, Heading, Link as DsLink, Skeleton } from '@navikt/ds-react'
 import { logger } from '@navikt/next-logger'
 import { useRouter } from 'next/router'
@@ -30,6 +30,7 @@ function SykmeldingkvitteringPage(): ReactElement {
     const { data, error, isPending } = useSykmelding(sykmeldingId)
     const router = useRouter()
     const flexjarToggle = useToggle('flexjar-sykmelding-kvittering')
+    const [optInSuksess, setOptInSuksess] = useState(false)
 
     const arbeissituasjonSvar = { arbeidssituasjon: data?.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar }
     if (isPending) {
@@ -93,6 +94,19 @@ function SykmeldingkvitteringPage(): ReactElement {
 
     return (
         <KvitteringWrapper sykmelding={data}>
+            {optInSuksess && (
+                <div className="mb-8">
+                    <Alert variant="info" role="status">
+                        <Heading size="small" level="3" spacing>
+                            Vi oppretter søknad etter sykmeldingsperioden er over
+                        </Heading>
+                        <BodyShort>
+                            Du vil få beskjed av oss når du skal fylle ut og sende inn søknaden om sykepenger for
+                            sykmeldingsperioden.
+                        </BodyShort>
+                    </Alert>
+                </div>
+            )}
             <div className="mb-8">
                 <StatusBanner
                     sykmeldingStatus={data.sykmeldingStatus}
@@ -102,7 +116,11 @@ function SykmeldingkvitteringPage(): ReactElement {
             </div>
             {(arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
                 arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.FRILANSER) && (
-                <VentetidInfo sykmeldingId={sykmeldingId} optInFrist={optInFrist} />
+                <VentetidInfo
+                    sykmeldingId={sykmeldingId}
+                    optInFrist={optInFrist}
+                    onOptInSuccess={() => setOptInSuksess(true)}
+                />
             )}
             <div className="mb-8">
                 <StatusInfo

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -5,6 +5,7 @@ import { logger } from '@navikt/next-logger'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { range } from 'remeda'
+import dayjs from 'dayjs'
 
 import { RegelStatus, StatusEvent, Sykmelding } from '../../../types/sykmelding/sykmelding'
 import StatusBanner from '../../../components/StatusBanner/StatusBanner'
@@ -32,6 +33,13 @@ function SykmeldingkvitteringPage(): ReactElement {
     const flexjarToggle = useToggle('flexjar-sykmelding-kvittering')
 
     const arbeissituasjonSvar = { arbeidssituasjon: data?.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar }
+
+    const sykmeldingNyereEnn4Mnd = (): boolean => {
+        return (
+            data?.sykmeldingStatus.timestamp != null &&
+            dayjs(data.sykmeldingStatus.timestamp).isAfter(dayjs().subtract(4, 'months'))
+        )
+    }
 
     if (isPending) {
         return (
@@ -104,7 +112,7 @@ function SykmeldingkvitteringPage(): ReactElement {
             </div>
             {(arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
                 arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.FRILANSER) && (
-                <VentetidInfo sykmeldingId={sykmeldingId} />
+                <VentetidInfo sykmeldingId={sykmeldingId} sykmeldingNyereEnn4Mnd={sykmeldingNyereEnn4Mnd()} />
             )}
             <div className="mb-8">
                 <StatusInfo

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -5,7 +5,6 @@ import { logger } from '@navikt/next-logger'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { range } from 'remeda'
-import dayjs from 'dayjs'
 
 import { RegelStatus, StatusEvent, Sykmelding } from '../../../types/sykmelding/sykmelding'
 import StatusBanner from '../../../components/StatusBanner/StatusBanner'
@@ -13,7 +12,11 @@ import StatusInfo from '../../../components/StatusInfo/StatusInfo'
 import useGetSykmeldingIdParam from '../../../hooks/useGetSykmeldingIdParam'
 import Header from '../../../components/Header/Header'
 import PageWrapper from '../../../components/PageWrapper/PageWrapper'
-import { getReadableSykmeldingLength, getSentSykmeldingTitle } from '../../../utils/sykmeldingUtils'
+import {
+    getReadableSykmeldingLength,
+    getSentSykmeldingTitle,
+    isSykmeldingNyereEnnFireMaaneder,
+} from '../../../utils/sykmeldingUtils'
 import HintToNextOlderSykmelding from '../../../components/ForceOrder/HintToNextOlderSykmelding'
 import SykmeldingArbeidsgiverExpansionCard from '../../../components/Sykmelding/SykmeldingerArbeidsgiver/SykmeldingArbeidsgiverExpansionCard'
 import SykmeldingSykmeldtSection from '../../../components/Sykmelding/SykmeldingerSykmeldt/SykmeldingSykmeldtSection'
@@ -33,13 +36,6 @@ function SykmeldingkvitteringPage(): ReactElement {
     const flexjarToggle = useToggle('flexjar-sykmelding-kvittering')
 
     const arbeissituasjonSvar = { arbeidssituasjon: data?.sykmeldingStatus.brukerSvar?.arbeidssituasjon.svar }
-
-    const sykmeldingNyereEnn4Mnd = (): boolean => {
-        return (
-            data?.sykmeldingStatus.timestamp != null &&
-            dayjs(data.sykmeldingStatus.timestamp).isAfter(dayjs().subtract(4, 'months'))
-        )
-    }
 
     if (isPending) {
         return (
@@ -101,6 +97,8 @@ function SykmeldingkvitteringPage(): ReactElement {
         )
     }
 
+    const sykmeldingNyereEnn4Mnd = isSykmeldingNyereEnnFireMaaneder(data)
+
     return (
         <KvitteringWrapper sykmelding={data}>
             <div className="mb-8">
@@ -112,7 +110,7 @@ function SykmeldingkvitteringPage(): ReactElement {
             </div>
             {(arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
                 arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.FRILANSER) && (
-                <VentetidInfo sykmeldingId={sykmeldingId} sykmeldingNyereEnn4Mnd={sykmeldingNyereEnn4Mnd()} />
+                <VentetidInfo sykmeldingId={sykmeldingId} sykmeldingNyereEnn4Mnd={sykmeldingNyereEnn4Mnd} />
             )}
             <div className="mb-8">
                 <StatusInfo

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -23,32 +23,7 @@ import { Flexjar } from '../../../components/flexjar/flexjar'
 import { useToggle } from '../../../toggles/context'
 import useSykmelding from '../../../hooks/sykmelding/useSykmelding'
 import { ArbeidssituasjonType } from '../../../types/sykmelding/sykmeldingCommon'
-import { LenkeMedIkon } from '../../../components/lenke/lenke-med-ikon'
-
-function NaringsdrivendeVentetidInfo() {
-    return (
-        <>
-            <Heading size="medium" level="2" spacing>
-                Hva skjer videre?
-            </Heading>
-            <BodyShort className="mt-6" weight="semibold" spacing>
-                Hvis du er syk i mindre enn 16 dager
-            </BodyShort>
-            <BodyShort spacing>
-                Du får som hovedregel ikke sykepenger de første 16 kalenderdagene. Dagene telles fra du oppsøker lege,
-                eller fra Nav får beskjed om at du er syk og ikke kan jobbe.
-            </BodyShort>
-            <BodyShort className="mt-6" weight="semibold" spacing>
-                Hvis du er syk i mer enn 16 dager
-            </BodyShort>
-            <BodyShort spacing>
-                Varer sykefraværet ditt mer enn 16 dager, dekker Nav sykepengene dine fra dag 17. Vi gir deg beskjed når
-                du kan søke om sykepenger.
-            </BodyShort>
-            <LenkeMedIkon href="https://www.nav.no/sykepenger#hva" text="Les mer om hva du kan få i sykepenger." />
-        </>
-    )
-}
+import { VentetidInfo } from '../../../components/SykmeldingVentetid/VentetidInfo'
 
 function SykmeldingkvitteringPage(): ReactElement {
     const sykmeldingId = useGetSykmeldingIdParam()
@@ -129,7 +104,7 @@ function SykmeldingkvitteringPage(): ReactElement {
             </div>
             {(arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.NAERINGSDRIVENDE ||
                 arbeissituasjonSvar.arbeidssituasjon === ArbeidssituasjonType.FRILANSER) && (
-                <NaringsdrivendeVentetidInfo />
+                <VentetidInfo sykmeldingId={sykmeldingId} />
             )}
             <div className="mb-8">
                 <StatusInfo

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -24,6 +24,7 @@ import { useToggle } from '../../../toggles/context'
 import useSykmelding from '../../../hooks/sykmelding/useSykmelding'
 import { ArbeidssituasjonType } from '../../../types/sykmelding/sykmeldingCommon'
 import { VentetidInfo } from '../../../components/SykmeldingVentetid/VentetidInfo'
+import { OptInSuksessAlert } from '../../../components/SykmeldingVentetid/OptInSuksessAlert'
 
 function SykmeldingkvitteringPage(): ReactElement {
     const sykmeldingId = useGetSykmeldingIdParam()
@@ -96,15 +97,7 @@ function SykmeldingkvitteringPage(): ReactElement {
         <KvitteringWrapper sykmelding={data}>
             {optInSuksess && (
                 <div className="mb-8">
-                    <Alert variant="info" role="status">
-                        <Heading size="small" level="3" spacing>
-                            Vi oppretter søknad etter sykmeldingsperioden er over
-                        </Heading>
-                        <BodyShort>
-                            Du vil få beskjed av oss når du skal fylle ut og sende inn søknaden om sykepenger for
-                            sykmeldingsperioden.
-                        </BodyShort>
-                    </Alert>
+                    <OptInSuksessAlert />
                 </div>
             )}
             <div className="mb-8">

--- a/src/utils/sykmeldingUtils.test.ts
+++ b/src/utils/sykmeldingUtils.test.ts
@@ -9,6 +9,7 @@ import {
     getSykmeldingStartDate,
     getSykmeldingTitle,
     isActiveSykmelding,
+    isSykmeldingNyereEnnFireMaaneder,
     extractSykmeldingIdFromUrl,
     isValidSykmeldingId,
     validateSykmeldingId,
@@ -23,6 +24,7 @@ const minimalSykmelding: Sykmelding = {
     mottattTidspunkt: dateSub(testDato, { days: 1 }),
     behandlingsutfall: {
         status: RegelStatus.OK,
+        erUnderBehandling: false,
         ruleHits: [],
     },
     arbeidsgiver: null,
@@ -128,6 +130,40 @@ describe('isActiveSykmelding', () => {
                     sykmeldingStatus: {
                         ...minimalSykmelding.sykmeldingStatus,
                         statusEvent: StatusEvent.APEN,
+                    },
+                },
+                testDato,
+            ),
+        ).toBe(false)
+    })
+})
+
+describe('isSykmeldingNyereEnnFireMaaneder', () => {
+    it('burde være true når mottattTidspunkt er nyere enn fire måneder', () => {
+        expect(
+            isSykmeldingNyereEnnFireMaaneder(
+                {
+                    ...minimalSykmelding,
+                    mottattTidspunkt: dateSub(testDato, { months: 3 }),
+                    sykmeldingStatus: {
+                        ...minimalSykmelding.sykmeldingStatus,
+                        timestamp: dateSub(testDato, { months: 12 }),
+                    },
+                },
+                testDato,
+            ),
+        ).toBe(true)
+    })
+
+    it('burde være false når mottattTidspunkt er eldre enn fire måneder', () => {
+        expect(
+            isSykmeldingNyereEnnFireMaaneder(
+                {
+                    ...minimalSykmelding,
+                    mottattTidspunkt: dateSub(testDato, { months: 5 }),
+                    sykmeldingStatus: {
+                        ...minimalSykmelding.sykmeldingStatus,
+                        timestamp: dateSub(testDato, { months: 1 }),
                     },
                 },
                 testDato,

--- a/src/utils/sykmeldingUtils.test.ts
+++ b/src/utils/sykmeldingUtils.test.ts
@@ -1,22 +1,23 @@
 import { describe, expect, it } from 'vitest'
+import { addDays, addMonths } from 'date-fns'
 
 import { Merknadtype, RegelStatus, StatusEvent, Sykmelding } from '../types/sykmelding/sykmelding'
 import { testDato } from '../data/mock/mock-db/data-creators'
 
 import {
+    extractSykmeldingIdFromUrl,
+    extractSykmeldingIdPdfUrl,
+    finnOptInFrist,
     getReadableSykmeldingLength,
     getSykmeldingEndDate,
     getSykmeldingStartDate,
     getSykmeldingTitle,
     isActiveSykmelding,
-    isSykmeldingNyereEnnFireMaaneder,
-    extractSykmeldingIdFromUrl,
+    isPostSykmeldingSend,
     isValidSykmeldingId,
     validateSykmeldingId,
-    isPostSykmeldingSend,
-    extractSykmeldingIdPdfUrl,
 } from './sykmeldingUtils'
-import { dateSub } from './dateUtils'
+import { dateSub, toDate } from './dateUtils'
 import { createSykmeldingPeriode } from './test/dataUtils'
 
 const minimalSykmelding: Sykmelding = {
@@ -138,37 +139,31 @@ describe('isActiveSykmelding', () => {
     })
 })
 
-describe('isSykmeldingNyereEnnFireMaaneder', () => {
-    it('burde være true når mottattTidspunkt er nyere enn fire måneder', () => {
-        expect(
-            isSykmeldingNyereEnnFireMaaneder(
-                {
-                    ...minimalSykmelding,
-                    mottattTidspunkt: dateSub(testDato, { months: 3 }),
-                    sykmeldingStatus: {
-                        ...minimalSykmelding.sykmeldingStatus,
-                        timestamp: dateSub(testDato, { months: 12 }),
-                    },
-                },
-                testDato,
-            ),
-        ).toBe(true)
+describe('finnOptInFrist', () => {
+    it('burde returnere fire måneder og én dag etter mottattTidspunkt', () => {
+        const sykmelding = {
+            ...minimalSykmelding,
+            mottattTidspunkt: dateSub(testDato, { months: 3 }),
+        }
+
+        expect(finnOptInFrist(sykmelding).getTime()).toBe(
+            addDays(addMonths(toDate(sykmelding.mottattTidspunkt), 4), 1).getTime(),
+        )
     })
 
-    it('burde være false når mottattTidspunkt er eldre enn fire måneder', () => {
-        expect(
-            isSykmeldingNyereEnnFireMaaneder(
-                {
-                    ...minimalSykmelding,
-                    mottattTidspunkt: dateSub(testDato, { months: 5 }),
-                    sykmeldingStatus: {
-                        ...minimalSykmelding.sykmeldingStatus,
-                        timestamp: dateSub(testDato, { months: 1 }),
-                    },
-                },
-                testDato,
-            ),
-        ).toBe(false)
+    it('burde bruke mottattTidspunkt og ikke sykmeldingStatus.timestamp', () => {
+        const sykmelding = {
+            ...minimalSykmelding,
+            mottattTidspunkt: dateSub(testDato, { months: 5 }),
+            sykmeldingStatus: {
+                ...minimalSykmelding.sykmeldingStatus,
+                timestamp: dateSub(testDato, { months: 1 }),
+            },
+        }
+
+        expect(finnOptInFrist(sykmelding).getTime()).toBe(
+            addDays(addMonths(toDate(sykmelding.mottattTidspunkt), 4), 1).getTime(),
+        )
     })
 })
 

--- a/src/utils/sykmeldingUtils.ts
+++ b/src/utils/sykmeldingUtils.ts
@@ -1,4 +1,4 @@
-import { differenceInDays, isAfter, isBefore, subMonths } from 'date-fns'
+import { addDays, addMonths, differenceInDays, isAfter, isBefore } from 'date-fns'
 
 import { RegelStatus, StatusEvent, Sykmelding } from '../types/sykmelding/sykmelding'
 
@@ -13,8 +13,8 @@ export function isActiveSykmelding(sykmelding: Sykmelding, dagensDato: Date = ne
     return differenceInDays(dagensDato, mottattDate) < 365
 }
 
-export function isSykmeldingNyereEnnFireMaaneder(sykmelding: Sykmelding, dagensDato: Date = new Date()): boolean {
-    return isAfter(toDate(sykmelding.mottattTidspunkt), subMonths(dagensDato, 4))
+export function finnOptInFrist(sykmelding: Sykmelding): Date {
+    return addDays(addMonths(toDate(sykmelding.mottattTidspunkt), 4), 1)
 }
 
 export function isUnderbehandling(sykmelding: Sykmelding): boolean {

--- a/src/utils/sykmeldingUtils.ts
+++ b/src/utils/sykmeldingUtils.ts
@@ -1,4 +1,4 @@
-import { differenceInDays, isAfter, isBefore } from 'date-fns'
+import { differenceInDays, isAfter, isBefore, subMonths } from 'date-fns'
 
 import { RegelStatus, StatusEvent, Sykmelding } from '../types/sykmelding/sykmelding'
 
@@ -11,6 +11,10 @@ export function isActiveSykmelding(sykmelding: Sykmelding, dagensDato: Date = ne
     // APEN sykmeldinger blir inaktive etter 12 måneder
     const mottattDate = toDate(sykmelding.mottattTidspunkt)
     return differenceInDays(dagensDato, mottattDate) < 365
+}
+
+export function isSykmeldingNyereEnnFireMaaneder(sykmelding: Sykmelding, dagensDato: Date = new Date()): boolean {
+    return isAfter(toDate(sykmelding.mottattTidspunkt), subMonths(dagensDato, 4))
 }
 
 export function isUnderbehandling(sykmelding: Sykmelding): boolean {


### PR DESCRIPTION
## Hva gjør denne PR-en?

Opt-in-informasjonen (`VentetidInfo`-komponenten med søknadsknapp) ble tidligere vist for alle næringsdrivende og frilansere uavhengig av ventetidsstatus. Nå vises den kun når sykmeldingen faktisk er **innenfor** ventetiden (`erUtenforVentetid === false`).

Gjelder to steder:
- **Kvitteringssiden** — etter at brukeren har sendt inn sykmeldingen
- **Innsendt sykmelding** (BEKREFTET-visning) — når brukeren åpner en tidligere innsendt sykmelding

## Teknisk løsning

- Legger til `enabled`-parameter i `useErUtenforVentetid`-hooken for å unngå unødige API-kall når arbeidssituasjonen ikke er næringsdrivende/frilanser
- Gater rendering av `VentetidInfo` på `erNaeringsdrivendeEllerFrilanser && utenforVentetidData?.erUtenforVentetid === false`
- Mens ventetiddata lastes (`undefined`) skjules komponenten — trygg default

## Testing

Nye Playwright-tester i `playwright/sykmelding/ventetid-opt-in.spec.ts`:
- ✅ Viser opt-in info innenfor ventetiden (innsendt sykmelding)
- ✅ Skjuler opt-in info utenfor ventetiden (innsendt sykmelding)
- ✅ Viser opt-in info innenfor ventetiden (kvittering)
- ✅ Skjuler opt-in info utenfor ventetiden (kvittering)

Nytt testscenario `bekreftetFrilanser` og utvidet `SykmeldingBuilder.bekreft()` til å støtte `NAERINGSDRIVENDE` og `FRILANSER`.

## AGENTS.md

Opprettet `AGENTS.md` med krav om at Playwright-tester alltid skal lages eller oppdateres ved ny funksjonalitet.