### PR TITLE
Rydd opp spacing og lenker i ForceOrder-komponenter

### DIFF
--- a/src/components/ForceOrder/ForceUseOlderSykmelding.tsx
+++ b/src/components/ForceOrder/ForceUseOlderSykmelding.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from 'react'
 import { BodyLong, Box, Button, GuidePanel, Heading, ReadMore } from '@navikt/ds-react'
-import Link from 'next/link'
+import NextLink from 'next/link'
 
 import { pluralize } from '../../utils/stringUtils'
 import { logEvent } from '../umami/umami'
@@ -30,20 +30,19 @@ function ForceUseOlderSykmelding({ olderSykmeldingId, olderSykmeldingCount }: Pr
                     </>
                 </ReadMore>
             </Box>
-            <Link href={`/sykmeldinger/${olderSykmeldingId}`} passHref>
-                <Button
-                    as="a"
-                    variant="primary"
-                    onClick={() =>
-                        logEvent('navigere', {
-                            destinasjon: 'neste ubrukte sykmelding (tvungen)',
-                            lenketekst: 'Gå til sykmeldingen',
-                        })
-                    }
-                >
-                    {olderSykmeldingCount > 1 ? 'Gå videre' : 'Gå til sykmeldingen'}
-                </Button>
-            </Link>
+            <Button
+                as={NextLink}
+                href={`/sykmeldinger/${olderSykmeldingId}`}
+                variant="primary"
+                onClick={() =>
+                    logEvent('navigere', {
+                        destinasjon: 'neste ubrukte sykmelding (tvungen)',
+                        lenketekst: 'Gå til sykmeldingen',
+                    })
+                }
+            >
+                {olderSykmeldingCount > 1 ? 'Gå videre' : 'Gå til sykmeldingen'}
+            </Button>
         </GuidePanel>
     )
 }

--- a/src/components/ForceOrder/ForceUseOlderSykmelding.tsx
+++ b/src/components/ForceOrder/ForceUseOlderSykmelding.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react'
-import { BodyLong, Button, GuidePanel, Heading, ReadMore } from '@navikt/ds-react'
+import { BodyLong, Box, Button, GuidePanel, Heading, ReadMore } from '@navikt/ds-react'
 import Link from 'next/link'
 
 import { pluralize } from '../../utils/stringUtils'
@@ -17,9 +17,9 @@ function ForceUseOlderSykmelding({ olderSykmeldingId, olderSykmeldingCount }: Pr
                 Før du kan begynne
             </Heading>
             Du har {pluralize('sykmelding', olderSykmeldingCount)} du må velge om du skal bruke, før du kan bruke denne.
-            <div className="mb-6 mt-4">
+            <Box marginBlock="space-16 space-24">
                 <ReadMore header="Hvorfor må jeg gjøre dette?">
-                    <div>
+                    <>
                         <BodyLong spacing>
                             Andre sykmeldingsperioder kan påvirke beløpet du skal få utbetalt for denne perioden.
                         </BodyLong>
@@ -27,9 +27,9 @@ function ForceUseOlderSykmelding({ olderSykmeldingId, olderSykmeldingCount }: Pr
                             Derfor må vi be deg om å velge om du skal bruke de sykmeldingene du har liggende, før du kan
                             begynne på denne.
                         </BodyLong>
-                    </div>
+                    </>
                 </ReadMore>
-            </div>
+            </Box>
             <Link href={`/sykmeldinger/${olderSykmeldingId}`} passHref>
                 <Button
                     as="a"

--- a/src/components/ForceOrder/HintToNextOlderSykmelding.tsx
+++ b/src/components/ForceOrder/HintToNextOlderSykmelding.tsx
@@ -1,5 +1,5 @@
 import { BodyLong, Box, Button, GuidePanel } from '@navikt/ds-react'
-import Link from 'next/link'
+import NextLink from 'next/link'
 import { ReactElement, useEffect } from 'react'
 
 import { toEarliestSykmelding, filterUnsentSykmeldinger } from '../../utils/findOlderSykmeldingId'
@@ -28,20 +28,19 @@ function HintToNextOlderSykmelding(): ReactElement | null {
                 <BodyLong spacing>
                     Du har {pluralize('sykmelding', unsentSykmeldinger.length)} du må velge om du skal bruke
                 </BodyLong>
-                <Link passHref href={`/sykmeldinger/${earliestId}`}>
-                    <Button
-                        as="a"
-                        variant="primary"
-                        onClick={() =>
-                            logUmamiEvent({
-                                eventName: 'navigere',
-                                data: { destinasjon: 'neste ubrukte sykmelding', lenketekst: 'Gå til sykmeldingen' },
-                            })
-                        }
-                    >
-                        {unsentSykmeldinger.length > 1 ? 'Gå videre' : 'Gå til sykmeldingen'}
-                    </Button>
-                </Link>
+                <Button
+                    as={NextLink}
+                    href={`/sykmeldinger/${earliestId}`}
+                    variant="primary"
+                    onClick={() =>
+                        logUmamiEvent({
+                            eventName: 'navigere',
+                            data: { destinasjon: 'neste ubrukte sykmelding', lenketekst: 'Gå til sykmeldingen' },
+                        })
+                    }
+                >
+                    {unsentSykmeldinger.length > 1 ? 'Gå videre' : 'Gå til sykmeldingen'}
+                </Button>
             </GuidePanel>
         </Box>
     )

--- a/src/components/ForceOrder/HintToNextOlderSykmelding.tsx
+++ b/src/components/ForceOrder/HintToNextOlderSykmelding.tsx
@@ -1,4 +1,4 @@
-import { BodyLong, Box, Button, GuidePanel } from '@navikt/ds-react'
+import { BodyLong, Button, GuidePanel } from '@navikt/ds-react'
 import NextLink from 'next/link'
 import { ReactElement, useEffect } from 'react'
 
@@ -23,26 +23,24 @@ function HintToNextOlderSykmelding(): ReactElement | null {
     const earliestId = earliest.id
 
     return (
-        <Box marginBlock="space-32 space-0">
-            <GuidePanel poster>
-                <BodyLong spacing>
-                    Du har {pluralize('sykmelding', unsentSykmeldinger.length)} du må velge om du skal bruke
-                </BodyLong>
-                <Button
-                    as={NextLink}
-                    href={`/sykmeldinger/${earliestId}`}
-                    variant="primary"
-                    onClick={() =>
-                        logUmamiEvent({
-                            eventName: 'navigere',
-                            data: { destinasjon: 'neste ubrukte sykmelding', lenketekst: 'Gå til sykmeldingen' },
-                        })
-                    }
-                >
-                    {unsentSykmeldinger.length > 1 ? 'Gå videre' : 'Gå til sykmeldingen'}
-                </Button>
-            </GuidePanel>
-        </Box>
+        <GuidePanel poster>
+            <BodyLong spacing>
+                Du har {pluralize('sykmelding', unsentSykmeldinger.length)} du må velge om du skal bruke
+            </BodyLong>
+            <Button
+                as={NextLink}
+                href={`/sykmeldinger/${earliestId}`}
+                variant="primary"
+                onClick={() =>
+                    logUmamiEvent({
+                        eventName: 'navigere',
+                        data: { destinasjon: 'neste ubrukte sykmelding', lenketekst: 'Gå til sykmeldingen' },
+                    })
+                }
+            >
+                {unsentSykmeldinger.length > 1 ? 'Gå videre' : 'Gå til sykmeldingen'}
+            </Button>
+        </GuidePanel>
     )
 }
 

--- a/src/components/ForceOrder/HintToNextOlderSykmelding.tsx
+++ b/src/components/ForceOrder/HintToNextOlderSykmelding.tsx
@@ -23,7 +23,7 @@ function HintToNextOlderSykmelding(): ReactElement | null {
     const earliestId = earliest.id
 
     return (
-        <Box marginBlockStart="space-32">
+        <Box marginBlock="space-32 space-0">
             <GuidePanel poster>
                 <BodyLong spacing>
                     Du har {pluralize('sykmelding', unsentSykmeldinger.length)} du må velge om du skal bruke

--- a/src/components/ForceOrder/HintToNextOlderSykmelding.tsx
+++ b/src/components/ForceOrder/HintToNextOlderSykmelding.tsx
@@ -1,4 +1,4 @@
-import { BodyLong, Button, GuidePanel } from '@navikt/ds-react'
+import { BodyLong, Box, Button, GuidePanel } from '@navikt/ds-react'
 import Link from 'next/link'
 import { ReactElement, useEffect } from 'react'
 
@@ -23,25 +23,27 @@ function HintToNextOlderSykmelding(): ReactElement | null {
     const earliestId = earliest.id
 
     return (
-        <GuidePanel poster className="mt-8">
-            <BodyLong spacing>
-                Du har {pluralize('sykmelding', unsentSykmeldinger.length)} du må velge om du skal bruke
-            </BodyLong>
-            <Link passHref href={`/sykmeldinger/${earliestId}`}>
-                <Button
-                    as="a"
-                    variant="primary"
-                    onClick={() =>
-                        logUmamiEvent({
-                            eventName: 'navigere',
-                            data: { destinasjon: 'neste ubrukte sykmelding', lenketekst: 'Gå til sykmeldingen' },
-                        })
-                    }
-                >
-                    {unsentSykmeldinger.length > 1 ? 'Gå videre' : 'Gå til sykmeldingen'}
-                </Button>
-            </Link>
-        </GuidePanel>
+        <Box marginBlockStart="space-32">
+            <GuidePanel poster>
+                <BodyLong spacing>
+                    Du har {pluralize('sykmelding', unsentSykmeldinger.length)} du må velge om du skal bruke
+                </BodyLong>
+                <Link passHref href={`/sykmeldinger/${earliestId}`}>
+                    <Button
+                        as="a"
+                        variant="primary"
+                        onClick={() =>
+                            logUmamiEvent({
+                                eventName: 'navigere',
+                                data: { destinasjon: 'neste ubrukte sykmelding', lenketekst: 'Gå til sykmeldingen' },
+                            })
+                        }
+                    >
+                        {unsentSykmeldinger.length > 1 ? 'Gå videre' : 'Gå til sykmeldingen'}
+                    </Button>
+                </Link>
+            </GuidePanel>
+        </Box>
     )
 }
 

--- a/src/components/SykmeldingViews/INVALID/BEKREFTET/InvalidBekreftetSykmelding.tsx
+++ b/src/components/SykmeldingViews/INVALID/BEKREFTET/InvalidBekreftetSykmelding.tsx
@@ -1,3 +1,4 @@
+import { Box } from '@navikt/ds-react'
 import { ReactElement } from 'react'
 
 import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
@@ -31,7 +32,9 @@ function InvalidBekreftetSykmelding({ sykmelding }: InvalidBekreftetSykmeldingPr
 
             <SykmeldingSykmeldtSection sykmelding={sykmelding} />
 
-            <HintToNextOlderSykmelding />
+            <Box marginBlock="space-32 space-0">
+                <HintToNextOlderSykmelding />
+            </Box>
         </div>
     )
 }

--- a/src/components/SykmeldingViews/OK/AVBRUTT/OkAvbruttSykmelding.tsx
+++ b/src/components/SykmeldingViews/OK/AVBRUTT/OkAvbruttSykmelding.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react'
-import { Alert, Button, Detail, Heading } from '@navikt/ds-react'
+import { Alert, Box, Button, Detail, Heading } from '@navikt/ds-react'
 import { PencilWritingIcon } from '@navikt/aksel-icons'
 
 import { Sykmelding } from '../../../../types/sykmelding/sykmelding'
@@ -41,7 +41,9 @@ function OkAvbruttSykmelding({ sykmelding, reopen }: OkAvbruttSykmeldingProps): 
             )}
             <SykmeldingSykmeldtSection sykmelding={sykmelding} />
 
-            <HintToNextOlderSykmelding />
+            <Box marginBlock="space-32 space-0">
+                <HintToNextOlderSykmelding />
+            </Box>
         </div>
     )
 }

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 import React, { Fragment, PropsWithChildren, ReactElement } from 'react'
-import { Alert, BodyShort, GuidePanel, Heading, Link as DsLink, Skeleton } from '@navikt/ds-react'
+import { Alert, BodyShort, Box, GuidePanel, Heading, Link as DsLink, Skeleton } from '@navikt/ds-react'
 import { logger } from '@navikt/next-logger'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
@@ -118,7 +118,9 @@ function SykmeldingkvitteringPage(): ReactElement {
                 />
             </div>
             {data.sykmeldingStatus.statusEvent === 'SENDT' && <SykmeldingArbeidsgiverExpansionCard sykmelding={data} />}
-            <HintToNextOlderSykmelding />
+            <Box marginBlock="space-32 space-0">
+                <HintToNextOlderSykmelding />
+            </Box>
             {flexjarToggle.enabled && (
                 <Flexjar feedbackId="sykmelding-kvittering" feedbackProps={arbeissituasjonSvar} />
             )}


### PR DESCRIPTION
## Hva gjør denne PR-en?

Rydder opp i to komponenter som tvinger brukeren til å behandle eldre sykmeldinger i riktig rekkefølge: `ForceUseOlderSykmelding` og `HintToNextOlderSykmelding`.

## Endringer

### Spacing — Tailwind → Aksel Box
Erstatter Tailwind CSS-klasser (`mt-4`, `mb-6`, `mt-8`) med Aksel spacing-tokens via `Box`-komponenten. Blandede spacing-systemer gir inkonsistens og er vanskeligere å vedlikeholde.

Marginen på `HintToNextOlderSykmelding` er lagt til foreldrene (`OkAvbruttSykmelding`, `InvalidBekreftetSykmelding`, `kvittering`) fremfor inne i selve komponenten — komponenter bør ikke eie sin egen ytre margin.

### Navigasjonsknapper — Link-wrapper → OverridableComponent
Erstatter det utdaterte `<Link passHref><Button as="a">`-mønsteret med `<Button as={NextLink} href="...">`.

Fra Next.js 13+ ignoreres `passHref` uten `legacyBehavior`, noe som gjør det gamle mønsteret feil. Aksels `Button` støtter `OverridableComponent`-API-et, som lar deg sende `NextLink` direkte via `as`-propen — ingen wrapper nødvendig.