### PR TITLE
Ikke send tom flexjar-melding ved avbryt i AnnetArbeidssituasjonSurvey

### DIFF
--- a/src/components/flexjar/AnnetArbeidssituasjonSurvey.test.tsx
+++ b/src/components/flexjar/AnnetArbeidssituasjonSurvey.test.tsx
@@ -60,14 +60,10 @@ describe('AnnetArbeidssituasjonSurvey', () => {
         expect(screen.getByRole('button', { name: 'Send tilbakemelding' })).toBeInTheDocument()
     })
 
-    it('initierer feedback ved mount', () => {
+    it('sender ikke feedback ved mount uten valgt årsak', () => {
         render(<AnnetArbeidssituasjonSurvey />)
 
-        expect(opprettFeedbackMutate).toHaveBeenCalledWith({
-            feedback: '',
-            feedbackId: 'arbeidssituasjon-annet',
-            svar: '',
-        })
+        expect(opprettFeedbackMutate).not.toHaveBeenCalled()
     })
 
     it('viser valideringsfeil ved send uten valgt årsak', async () => {
@@ -117,6 +113,36 @@ describe('AnnetArbeidssituasjonSurvey', () => {
 
         await userEvent.click(screen.getByRole('radio', { name: 'Jeg er pensjonist' }))
         expect(screen.queryByLabelText(/Skriv hvilken arbeidssituasjon/i)).not.toBeInTheDocument()
+    })
+
+    it('sender feedback når bruker gjør første valg', async () => {
+        render(<AnnetArbeidssituasjonSurvey />)
+
+        expect(opprettFeedbackMutate).not.toHaveBeenCalled()
+
+        await userEvent.click(screen.getByRole('radio', { name: 'Jeg er pensjonist' }))
+
+        expect(opprettFeedbackMutate).toHaveBeenCalledWith({
+            feedback: '',
+            feedbackId: 'arbeidssituasjon-annet',
+            svar: 'PENSJONIST',
+        })
+    })
+
+    it('oppdaterer eksisterende post (ikke oppretter på nytt) når data.id er satt', async () => {
+        mockFeedbackData = { id: 'test-id' }
+        render(<AnnetArbeidssituasjonSurvey />)
+
+        await userEvent.click(screen.getByRole('radio', { name: 'Jeg er pensjonist' }))
+        await userEvent.click(screen.getByRole('radio', { name: 'Jeg mottar AAP' }))
+
+        expect(opprettFeedbackMutate).not.toHaveBeenCalled()
+        expect(oppdaterFeedbackMutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                id: 'test-id',
+                body: expect.objectContaining({ svar: 'AAP' }),
+            }),
+        )
     })
 
     it('kaller onTakk når feedback er sendt', async () => {

--- a/src/components/flexjar/AnnetArbeidssituasjonSurvey.tsx
+++ b/src/components/flexjar/AnnetArbeidssituasjonSurvey.tsx
@@ -24,6 +24,7 @@ export function AnnetArbeidssituasjonSurvey({ onTakk }: { onTakk?: () => void })
     const [valideringsfeil, setValideringsfeil] = useState<string | null>(null)
     const [takk, setTakk] = useState(false)
     const takkRef = useRef<HTMLDivElement>(null)
+    const fritekstRef = useRef<HTMLTextAreaElement>(null)
 
     const { mutate: opprettFeedback, data } = UseOpprettFlexjarFeedback()
     const { mutate: oppdaterFeedback } = UseOppdaterFlexjarFeedback()
@@ -43,9 +44,10 @@ export function AnnetArbeidssituasjonSurvey({ onTakk }: { onTakk?: () => void })
     }
 
     useEffect(() => {
+        if (!valgtArsak) return
         sendFeedback()
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    }, [valgtArsak])
 
     const handleSend = () => {
         if (!valgtArsak) {
@@ -108,6 +110,8 @@ export function AnnetArbeidssituasjonSurvey({ onTakk }: { onTakk?: () => void })
                         setValideringsfeil(null)
                         if (verdi !== 'ANNEN_ARSAK') {
                             setFritekst('')
+                        } else {
+                            setTimeout(() => fritekstRef.current?.focus(), 0)
                         }
                     }}
                     error={valideringsfeil}
@@ -121,6 +125,7 @@ export function AnnetArbeidssituasjonSurvey({ onTakk }: { onTakk?: () => void })
 
                 {valgtArsak === 'ANNEN_ARSAK' && (
                     <Textarea
+                        ref={fritekstRef}
                         label="Skriv hvilken arbeidssituasjon som gjelder deg"
                         description="Ikke skriv navn, fødselsnummer eller andre personlige opplysninger"
                         value={fritekst}


### PR DESCRIPTION
Send feedback kun når bruker gjør et valg, ikke ved mount.
Legg til autofokus på fritekstfelt når Annen årsak velges (a11y).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
