### PR TITLE
Oppgrader ESLint til v9 og TypeScript til v6 og migrer til flat config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-src/registerServiceWorker.js
-src/**/__tests__/**

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,35 @@
+import { defineConfig } from 'eslint/config'
+import nextVitals from 'eslint-config-next/core-web-vitals'
+import nextTs from 'eslint-config-next/typescript'
+import prettierRecommended from 'eslint-plugin-prettier/recommended'
+
+export default defineConfig([
+    { ignores: ['src/registerServiceWorker.js', 'src/**/__tests__/**'] },
+    ...nextVitals,
+    ...nextTs,
+    {
+        rules: {
+            'no-console': 'warn',
+            '@typescript-eslint/no-explicit-any': 'warn',
+            '@typescript-eslint/no-non-null-assertion': 'off',
+            '@typescript-eslint/explicit-function-return-type': 'off',
+            'react-hooks/exhaustive-deps': 'warn',
+            'react-hooks/set-state-in-effect': 'warn',
+            'react-hooks/refs': 'warn',
+            'react-hooks/immutability': 'warn',
+            'react-hooks/preserve-manual-memoization': 'warn',
+        },
+    },
+    {
+        files: ['playwright/**/*.{js,ts,tsx}'],
+        rules: {
+            'react-hooks/rules-of-hooks': 'off',
+        },
+    },
+    {
+        extends: [prettierRecommended],
+        rules: {
+            'prettier/prettier': 'warn',
+        },
+    },
+])

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
             },
             "devDependencies": {
                 "@axe-core/playwright": "^4.12.1",
-                "@navikt/eslint-config-teamsykmelding": "^8.1.3",
+                "@navikt/tsm-prettier": "^2.0.1",
                 "@playwright/test": "^1.61.1",
                 "@tailwindcss/postcss": "^4.3.3",
                 "@testing-library/dom": "^10.4.1",
@@ -61,8 +61,10 @@
                 "@vitejs/plugin-react": "^6.0.3",
                 "axe-core": "^4.12.1",
                 "dotenv": "^17.4.2",
-                "eslint": "^8.57.1",
-                "eslint-config-next": "^15.5.9",
+                "eslint": "^9.39.5",
+                "eslint-config-next": "^16.0.10",
+                "eslint-config-prettier": "^10.1.8",
+                "eslint-plugin-prettier": "^5.5.4",
                 "jsdom": "^26.1.0",
                 "next": "15.5.18",
                 "next-router-mock": "^1.0.5",
@@ -73,7 +75,7 @@
                 "prettier-plugin-tailwindcss": "^0.8.0",
                 "tailwindcss": "^4.3.3",
                 "ts-loader": "^9.6.2",
-                "typescript": "^5.9.3",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.10"
             },
             "engines": {
@@ -146,6 +148,64 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/compat-data": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/core": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
+                "@jridgewell/remapping": "^2.3.5",
+                "convert-source-map": "^2.0.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.2.3",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@babel/core/node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@babel/core/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
         "node_modules/@babel/generator": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -160,6 +220,33 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
+                "browserslist": "^4.24.0",
+                "lru-cache": "^5.1.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/helper-globals": {
@@ -184,6 +271,24 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-module-transforms": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -198,6 +303,30 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-validator-option": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helpers": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -598,24 +727,90 @@
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
-        "node_modules/@eslint/eslintrc": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-            "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+        "node_modules/@eslint/config-array": {
+            "version": "0.21.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+            "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "ajv": "^6.12.4",
+                "@eslint/object-schema": "^2.1.7",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.5"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+            "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/minimatch": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+            "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.17.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+            "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+            "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ajv": "^6.14.0",
                 "debug": "^4.3.2",
-                "espree": "^9.6.0",
-                "globals": "^13.19.0",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
-                "minimatch": "^3.1.2",
+                "js-yaml": "^4.3.0",
+                "minimatch": "^3.1.5",
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -632,21 +827,6 @@
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/globals": {
-            "version": "13.24.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-            "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -660,25 +840,41 @@
                 "node": "*"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+        "node_modules/@eslint/js": {
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+            "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=10"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://eslint.org/donate"
             }
         },
-        "node_modules/@eslint/js": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-            "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+            "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+            "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.17.0",
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
         "node_modules/@floating-ui/core": {
@@ -783,43 +979,42 @@
                 "uuid": "dist/bin/uuid"
             }
         },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-            "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-            "deprecated": "Use @eslint/config-array instead",
+        "node_modules/@humanfs/core": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.3",
-                "debug": "^4.3.1",
-                "minimatch": "^3.0.5"
+                "@humanfs/types": "^0.15.0"
             },
             "engines": {
-                "node": ">=10.10.0"
+                "node": ">=18.18.0"
             }
         },
-        "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+        "node_modules/@humanfs/node": {
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
-            "license": "MIT",
+            "license": "Apache-2.0",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
+                "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
-                "node": "*"
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -835,12 +1030,19 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-            "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-            "deprecated": "Use @eslint/object-schema instead",
-            "dev": true
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
         },
         "node_modules/@img/colour": {
             "version": "1.0.0",
@@ -1426,260 +1628,6 @@
             "integrity": "sha512-i76uLUIONOWc/G7kzPHQwNCR65bKBVulYbua6tyVmtlAhJyEPjC2vNyeeOq1bE4QcccPNQz9rBKydmXOVvJYtw==",
             "license": "MIT"
         },
-        "node_modules/@navikt/eslint-config-teamsykmelding": {
-            "version": "8.1.3",
-            "resolved": "https://npm.pkg.github.com/download/@navikt/eslint-config-teamsykmelding/8.1.3/e1198866c75d519e8ea4dbabb66946c7ddfb3c37",
-            "integrity": "sha512-HesdvHu1kgoFSndrS9sIZBGU3l8xIXzI9dSiA8v6Rfjn5/bVtfdFymosbrRZBtnAH4tASA1hOg2EUDmEz1pKJw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/eslint-plugin": "^8.40.0",
-                "@typescript-eslint/parser": "^8.40.0",
-                "eslint-config-prettier": "^10.1.8",
-                "eslint-plugin-import": "^2.32.0",
-                "eslint-plugin-prettier": "^5.5.4",
-                "eslint-plugin-react": "^7.37.5",
-                "eslint-plugin-react-hooks": "^5.2.0",
-                "eslint-plugin-testing-library": "^7.6.6"
-            },
-            "engines": {
-                "node": "22"
-            },
-            "peerDependencies": {
-                "eslint": ">=8",
-                "prettier": ">=2",
-                "typescript": ">=4"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.54.0.tgz",
-            "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.54.0",
-                "@typescript-eslint/type-utils": "8.54.0",
-                "@typescript-eslint/utils": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0",
-                "ignore": "^7.0.5",
-                "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.4.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/parser": "^8.54.0",
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/@typescript-eslint/parser": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
-            "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/typescript-estree": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0",
-                "debug": "^4.4.3"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
-            "integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/@typescript-eslint/type-utils": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz",
-            "integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/typescript-estree": "8.54.0",
-                "@typescript-eslint/utils": "8.54.0",
-                "debug": "^4.4.3",
-                "ts-api-utils": "^2.4.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/@typescript-eslint/types": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
-            "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
-            "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.54.0",
-                "@typescript-eslint/tsconfig-utils": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0",
-                "debug": "^4.4.3",
-                "minimatch": "^9.0.5",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/@typescript-eslint/utils": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
-            "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/typescript-estree": "8.54.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
-            "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "eslint-visitor-keys": "^4.2.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@navikt/eslint-config-teamsykmelding/node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4"
-            }
-        },
         "node_modules/@navikt/nav-dekoratoren-moduler": {
             "version": "3.7.3",
             "resolved": "https://npm.pkg.github.com/download/@navikt/nav-dekoratoren-moduler/3.7.3/3c790758f06d026b8732261131b13aa937055646",
@@ -1766,15 +1714,25 @@
                 "node": "^20.19.0 || >= 22.12.0 || 24.x || 25.x"
             }
         },
+        "node_modules/@navikt/tsm-prettier": {
+            "version": "2.0.1",
+            "resolved": "https://npm.pkg.github.com/download/@navikt/tsm-prettier/2.0.1/282dbeee88ec6aa5c3b0cfd8ff8ab9b65a6f1683",
+            "integrity": "sha512-lPZ5xGPI5zWvpZSjJhb0XtWozyW11R9kAcgTitWKAWOWYx5SMaixNUq4sTaB5FVTXM+BOQD4qn9NnNvQ9cEISQ==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "prettier": ">= 3"
+            }
+        },
         "node_modules/@next/env": {
             "version": "14.2.13",
             "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.13.tgz",
             "integrity": "sha512-s3lh6K8cbW1h5Nga7NNeXrbe0+2jIIYK9YaA9T7IufDWnZpozdFUp6Hf0d5rNWUKu4fEuSX2rCKlGjCrtylfDw=="
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "15.5.9",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.9.tgz",
-            "integrity": "sha512-kUzXx0iFiXw27cQAViE1yKWnz/nF8JzRmwgMRTMh8qMY90crNsdXJRh2e+R0vBpFR3kk1yvAR7wev7+fCCb79Q==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.12.tgz",
+            "integrity": "sha512-uF2z/qAK2q7B5/6CpnFcBRX6jOq5iCO+Uqh1UkJhXljX1JwLarLYhhoJadO6dPb6moTprOKewMXheBcbIoSbug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1973,6 +1931,7 @@
             "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
             "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=12.4.0"
             }
@@ -2643,12 +2602,6 @@
             "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
             "dev": true
         },
-        "node_modules/@rushstack/eslint-patch": {
-            "version": "1.10.4",
-            "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
-            "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
-            "dev": true
-        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3144,8 +3097,7 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -3204,75 +3156,55 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
-            "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
-            "dev": true,
-            "dependencies": {
-                "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "7.18.0",
-                "@typescript-eslint/type-utils": "7.18.0",
-                "@typescript-eslint/utils": "7.18.0",
-                "@typescript-eslint/visitor-keys": "7.18.0",
-                "graphemer": "^1.4.0",
-                "ignore": "^5.3.1",
-                "natural-compare": "^1.4.0",
-                "ts-api-utils": "^1.3.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/parser": "^7.0.0",
-                "eslint": "^8.56.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
-            "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "7.18.0",
-                "@typescript-eslint/types": "7.18.0",
-                "@typescript-eslint/typescript-estree": "7.18.0",
-                "@typescript-eslint/visitor-keys": "7.18.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.56.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/project-service": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.54.0.tgz",
-            "integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+            "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.54.0",
-                "@typescript-eslint/types": "^8.54.0",
+                "@eslint-community/regexpp": "^4.12.2",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/type-utils": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
+                "ignore": "^7.0.5",
+                "natural-compare": "^1.4.0",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^8.65.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/@typescript-eslint/parser": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+            "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -3283,34 +3215,44 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
-            "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+            "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.65.0",
+                "@typescript-eslint/types": "^8.65.0",
+                "debug": "^4.4.3"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
-            "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+            "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "7.18.0",
-                "@typescript-eslint/visitor-keys": "7.18.0"
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3318,9 +3260,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz",
-            "integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+            "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3331,43 +3273,42 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
-            "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+            "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "7.18.0",
-                "@typescript-eslint/utils": "7.18.0",
-                "debug": "^4.3.4",
-                "ts-api-utils": "^1.3.0"
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0",
+                "debug": "^4.4.3",
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.56.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
-            "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+            "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -3375,77 +3316,100 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
-            "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+            "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "7.18.0",
-                "@typescript-eslint/visitor-keys": "7.18.0",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "minimatch": "^9.0.4",
-                "semver": "^7.6.0",
-                "ts-api-utils": "^1.3.0"
+                "@typescript-eslint/project-service": "8.65.0",
+                "@typescript-eslint/tsconfig-utils": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/visitor-keys": "8.65.0",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
-            "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
-            "dev": true,
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "7.18.0",
-                "@typescript-eslint/types": "7.18.0",
-                "@typescript-eslint/typescript-estree": "7.18.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.56.0"
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+            "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.65.0",
+                "@typescript-eslint/types": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.18.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
-            "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+            "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "7.18.0",
-                "eslint-visitor-keys": "^3.4.3"
+                "@typescript-eslint/types": "8.65.0",
+                "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@ungap/structured-clone": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-            "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
-            "dev": true
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
         },
         "node_modules/@unleash/nextjs": {
             "version": "1.6.7",
@@ -3482,6 +3446,383 @@
             "peerDependencies": {
                 "unleash-proxy-client": "^3.7.3"
             }
+        },
+        "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+            "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-android-arm64": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+            "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-darwin-arm64": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+            "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-darwin-x64": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+            "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-freebsd-x64": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+            "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+            "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+            "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+            "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+            "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+            "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+            "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+            "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+            "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+            "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+            "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+            "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+            "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+            "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+            "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.1",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+            "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+            "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+            "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "6.0.3",
@@ -3852,6 +4193,7 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -3865,10 +4207,11 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -3953,7 +4296,8 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+            "dev": true,
+            "license": "Python-2.0"
         },
         "node_modules/aria-query": {
             "version": "5.3.0",
@@ -4001,15 +4345,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/array.prototype.findlast": {
@@ -4141,7 +4476,8 @@
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
             "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/atomic-sleep": {
             "version": "1.0.0",
@@ -4181,6 +4517,7 @@
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
             "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.4"
             }
@@ -4244,7 +4581,6 @@
             "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "baseline-browser-mapping": "dist/cli.cjs"
             },
@@ -4267,13 +4603,24 @@
             "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-            "dev": true,
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/brace-expansion/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -4326,7 +4673,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.42",
                 "caniuse-lite": "^1.0.30001803",
@@ -4386,27 +4732,6 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
-        "node_modules/cacache/node_modules/balanced-match": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-            "license": "MIT",
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/cacache/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
         "node_modules/cacache/node_modules/glob": {
             "version": "13.0.1",
             "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.1.tgz",
@@ -4431,21 +4756,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
-            }
-        },
-        "node_modules/cacache/node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "brace-expansion": "^5.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/cacache/node_modules/path-scurry": {
@@ -4743,7 +5053,8 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
-            "dev": true
+            "dev": true,
+            "license": "BSD-2-Clause"
         },
         "node_modules/data-urls": {
             "version": "5.0.0",
@@ -4969,30 +5280,6 @@
             "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
             "license": "MIT"
         },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/dom-accessibility-api": {
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -5098,8 +5385,14 @@
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
             "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
             "dev": true,
-            "license": "ISC",
-            "peer": true
+            "license": "ISC"
+        },
+        "node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/emoji-regex-xs": {
             "version": "1.0.0",
@@ -5350,7 +5643,6 @@
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5367,87 +5659,103 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.57.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-            "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-            "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+            "version": "9.39.5",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+            "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.57.1",
-                "@humanwhocodes/config-array": "^0.13.0",
+                "@eslint-community/eslint-utils": "^4.8.0",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.21.2",
+                "@eslint/config-helpers": "^0.4.2",
+                "@eslint/core": "^0.17.0",
+                "@eslint/eslintrc": "^3.3.6",
+                "@eslint/js": "9.39.5",
+                "@eslint/plugin-kit": "^0.4.1",
+                "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@nodelib/fs.walk": "^1.2.8",
-                "@ungap/structured-clone": "^1.2.0",
-                "ajv": "^6.12.4",
+                "@humanwhocodes/retry": "^0.4.2",
+                "@types/estree": "^1.0.6",
+                "ajv": "^6.14.0",
                 "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
+                "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.2",
-                "eslint-visitor-keys": "^3.4.3",
-                "espree": "^9.6.1",
-                "esquery": "^1.4.2",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
+                "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
+                "file-entry-cache": "^8.0.0",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.19.0",
-                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
-                "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
-                "minimatch": "^3.1.2",
+                "minimatch": "^3.1.5",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3",
-                "strip-ansi": "^6.0.1",
-                "text-table": "^0.2.0"
+                "optionator": "^0.9.3"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://opencollective.com/eslint"
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "15.5.9",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.9.tgz",
-            "integrity": "sha512-852JYI3NkFNzW8CqsMhI0K2CDRxTObdZ2jQJj5CtpEaOkYHn13107tHpNuD/h0WRpU4FAbCdUaxQsrfBtNK9Kw==",
+            "version": "16.2.12",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.12.tgz",
+            "integrity": "sha512-iaaf4vvKo5h2LBdGt0JuRv7t0Ysqr9FMCiFxbptDg8LqOE//mIKR80DdpOnSVM7qjLH3jT8P0aFiwXxBEGZRXw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@next/eslint-plugin-next": "15.5.9",
-                "@rushstack/eslint-patch": "^1.10.3",
-                "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-                "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+                "@next/eslint-plugin-next": "16.2.12",
                 "eslint-import-resolver-node": "^0.3.6",
                 "eslint-import-resolver-typescript": "^3.5.2",
-                "eslint-plugin-import": "^2.31.0",
+                "eslint-plugin-import": "^2.32.0",
                 "eslint-plugin-jsx-a11y": "^6.10.0",
                 "eslint-plugin-react": "^7.37.0",
-                "eslint-plugin-react-hooks": "^5.0.0"
+                "eslint-plugin-react-hooks": "^7.0.0",
+                "globals": "16.4.0",
+                "typescript-eslint": "^8.46.0"
             },
             "peerDependencies": {
-                "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
+                "eslint": ">=9.0.0",
                 "typescript": ">=3.3.1"
             },
             "peerDependenciesMeta": {
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/eslint-config-next/node_modules/globals": {
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+            "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint-config-prettier": {
@@ -5487,25 +5795,25 @@
             }
         },
         "node_modules/eslint-import-resolver-typescript": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.7.0.tgz",
-            "integrity": "sha512-Vrwyi8HHxY97K5ebydMtffsWAn1SCR9eol49eCd5fJS4O1WV7PaAjbcjmbfJJSMz/t4Mal212Uz/fQZrOB8mow==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+            "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "@nolyfill/is-core-module": "1.0.39",
-                "debug": "^4.3.7",
-                "enhanced-resolve": "^5.15.0",
-                "fast-glob": "^3.3.2",
-                "get-tsconfig": "^4.7.5",
-                "is-bun-module": "^1.0.2",
-                "is-glob": "^4.0.3",
-                "stable-hash": "^0.0.4"
+                "debug": "^4.4.0",
+                "get-tsconfig": "^4.10.0",
+                "is-bun-module": "^2.0.0",
+                "stable-hash": "^0.0.5",
+                "tinyglobby": "^0.2.13",
+                "unrs-resolver": "^1.6.2"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
             },
             "funding": {
-                "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+                "url": "https://opencollective.com/eslint-import-resolver-typescript"
             },
             "peerDependencies": {
                 "eslint": "*",
@@ -5519,34 +5827,6 @@
                 "eslint-plugin-import-x": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/eslint-import-resolver-typescript/node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/eslint-import-resolver-typescript/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/eslint-module-utils": {
@@ -5670,6 +5950,7 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
             "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "aria-query": "^5.3.2",
                 "array-includes": "^3.1.8",
@@ -5699,26 +5980,21 @@
             "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
             "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.4"
             }
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
-        },
-        "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true
         },
         "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
             "version": "3.1.5",
@@ -5798,16 +6074,23 @@
             }
         },
         "node_modules/eslint-plugin-react-hooks": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-            "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+            "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.24.4",
+                "@babel/parser": "^7.24.4",
+                "hermes-parser": "^0.25.1",
+                "zod": "^3.25.0 || ^4.0.0",
+                "zod-validation-error": "^3.5.0 || ^4.0.0"
+            },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
             }
         },
         "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
@@ -5872,175 +6155,18 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/eslint-plugin-testing-library": {
-            "version": "7.15.4",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.15.4.tgz",
-            "integrity": "sha512-qP0ZPWAvDrS3oxZJErUfn3SZiIzj5Zh2EWuyWxjR5Bsk84ntxpquh4D0USorfyw5MzECURQ8OcEeBQdspHatzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "^8.51.0",
-                "@typescript-eslint/utils": "^8.51.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
-            "integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/types": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
-            "integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
-            "integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/project-service": "8.54.0",
-                "@typescript-eslint/tsconfig-utils": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/visitor-keys": "8.54.0",
-                "debug": "^4.4.3",
-                "minimatch": "^9.0.5",
-                "semver": "^7.7.3",
-                "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.4.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/utils": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
-            "integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.54.0",
-                "@typescript-eslint/types": "8.54.0",
-                "@typescript-eslint/typescript-estree": "8.54.0"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <6.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.54.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
-            "integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "8.54.0",
-                "eslint-visitor-keys": "^4.2.1"
-            },
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/eslint-plugin-testing-library/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/eslint-plugin-testing-library/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/eslint-plugin-testing-library/node_modules/ts-api-utils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-            "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18.12"
-            },
-            "peerDependencies": {
-                "typescript": ">=4.8.4"
-            }
-        },
         "node_modules/eslint-scope": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -6069,19 +6195,17 @@
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/eslint/node_modules/globals": {
-            "version": "13.24.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-            "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+        "node_modules/eslint/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
+            "license": "Apache-2.0",
             "engines": {
-                "node": ">=8"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
@@ -6097,30 +6221,32 @@
                 "node": "*"
             }
         },
-        "node_modules/eslint/node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+        "node_modules/espree": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.1"
+            },
             "engines": {
-                "node": ">=10"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
+                "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+        "node_modules/espree/node_modules/eslint-visitor-keys": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
-            "dependencies": {
-                "acorn": "^8.9.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
+            "license": "Apache-2.0",
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -6246,7 +6372,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -6302,15 +6429,16 @@
             "license": "MIT"
         },
         "node_modules/file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "flat-cache": "^3.0.4"
+                "flat-cache": "^4.0.0"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/fill-range": {
@@ -6347,23 +6475,23 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-            "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "flatted": "^3.2.9",
-                "keyv": "^4.5.3",
-                "rimraf": "^3.0.2"
+                "keyv": "^4.5.4"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/flatted": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+            "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
             "dev": true,
             "license": "ISC"
         },
@@ -6411,12 +6539,6 @@
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
         },
         "node_modules/fsevents": {
             "version": "2.3.2",
@@ -6466,6 +6588,16 @@
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/get-intrinsic": {
@@ -6524,36 +6656,16 @@
             }
         },
         "node_modules/get-tsconfig": {
-            "version": "4.8.1",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
-            "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-            }
-        },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -6576,28 +6688,17 @@
             "license": "BSD-2-Clause",
             "peer": true
         },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+        "node_modules/globals": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
             "engines": {
-                "node": "*"
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/globalthis": {
@@ -6616,26 +6717,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6652,12 +6733,6 @@
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true
-        },
-        "node_modules/graphemer": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-            "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true
         },
         "node_modules/has-bigints": {
@@ -6750,6 +6825,23 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
             "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="
+        },
+        "node_modules/hermes-estree": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+            "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hermes-parser": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+            "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hermes-estree": "0.25.1"
+            }
         },
         "node_modules/hoist-non-react-statics": {
             "version": "3.3.2",
@@ -6944,17 +7036,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "dev": true,
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -7061,12 +7142,26 @@
             }
         },
         "node_modules/is-bun-module": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-1.3.0.tgz",
-            "integrity": "sha512-DgXeu5UWI0IsMQundYb5UAOzm6G2eVnarJ0byP6Tm55iZNKceD59LNPA2L4VvsScTtHcw0yEkVwSf7PC+QoLSA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+            "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "semver": "^7.6.3"
+                "semver": "^7.7.1"
+            }
+        },
+        "node_modules/is-bun-module/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/is-callable": {
@@ -7278,15 +7373,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/is-potential-custom-element-name": {
@@ -7650,7 +7736,8 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -7661,13 +7748,27 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
+        },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/jsx-ast-utils": {
             "version": "3.3.5",
@@ -7689,6 +7790,7 @@
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -7697,13 +7799,15 @@
             "version": "0.3.23",
             "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
             "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
-            "dev": true
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/language-tags": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
             "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "language-subtag-registry": "^0.3.20"
             },
@@ -8102,6 +8206,16 @@
                 "loose-envify": "cli.js"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^3.0.2"
+            }
+        },
         "node_modules/lz-string": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -8221,16 +8335,15 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
+            "version": "10.2.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+            "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^5.0.8"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -8397,6 +8510,22 @@
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
         },
+        "node_modules/napi-postinstall": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+            "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "napi-postinstall": "lib/cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/napi-postinstall"
+            }
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -8559,7 +8688,6 @@
             "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -8906,15 +9034,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
@@ -9662,6 +9781,7 @@
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
             "dev": true,
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
             }
@@ -9689,22 +9809,6 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/rolldown": {
@@ -10179,15 +10283,6 @@
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true
         },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/smart-buffer": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -10292,10 +10387,11 @@
             }
         },
         "node_modules/stable-hash": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
-            "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
-            "dev": true
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+            "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stackback": {
             "version": "0.0.2",
@@ -10338,6 +10434,7 @@
             "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
             "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7",
                 "define-properties": "^1.2.1",
@@ -10438,18 +10535,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/strip-bom": {
@@ -10687,12 +10772,6 @@
             "dev": true,
             "peer": true
         },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
-        },
         "node_modules/thread-stream": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -10857,15 +10936,16 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=18.12"
             },
             "peerDependencies": {
-                "typescript": ">=4.2.0"
+                "typescript": ">=4.8.4"
             }
         },
         "node_modules/ts-loader": {
@@ -11031,9 +11111,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -11042,6 +11122,30 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "8.65.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+            "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.65.0",
+                "@typescript-eslint/parser": "8.65.0",
+                "@typescript-eslint/typescript-estree": "8.65.0",
+                "@typescript-eslint/utils": "8.65.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/ua-parser-js": {
@@ -11210,6 +11314,44 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "node_modules/unrs-resolver": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+            "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "napi-postinstall": "^0.3.4"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unrs-resolver"
+            },
+            "optionalDependencies": {
+                "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+                "@unrs/resolver-binding-android-arm64": "1.12.2",
+                "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+                "@unrs/resolver-binding-darwin-x64": "1.12.2",
+                "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+                "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+                "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+                "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+                "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+                "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+                "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+                "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -11230,7 +11372,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -11247,6 +11388,7 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -11854,6 +11996,13 @@
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
         },
+        "node_modules/yallist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -11879,6 +12028,19 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-validation-error": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+            "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -44,8 +44,9 @@
     },
     "devDependencies": {
         "@axe-core/playwright": "^4.12.1",
-        "@navikt/eslint-config-teamsykmelding": "^8.1.3",
+        "@navikt/tsm-prettier": "^2.0.1",
         "@playwright/test": "^1.61.1",
+        "@tailwindcss/postcss": "^4.3.3",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -56,11 +57,12 @@
         "@types/react-dom": "^19.2.3",
         "@types/uuid": "^11.0.0",
         "@vitejs/plugin-react": "^6.0.3",
-        "@tailwindcss/postcss": "^4.3.3",
         "axe-core": "^4.12.1",
         "dotenv": "^17.4.2",
-        "eslint": "^8.57.1",
-        "eslint-config-next": "^15.5.9",
+        "eslint": "^9.39.5",
+        "eslint-config-next": "^16.0.10",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-prettier": "^5.5.4",
         "jsdom": "^26.1.0",
         "next": "15.5.18",
         "next-router-mock": "^1.0.5",
@@ -71,7 +73,7 @@
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^4.3.3",
         "ts-loader": "^9.6.2",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10"
     },
     "scripts": {
@@ -88,28 +90,9 @@
         "play-headless-build": "export BUILD=true; npm run build && npx playwright test",
         "prettier:write": "prettier --write .",
         "prettier:check": "prettier --check .",
-        "lint": "eslint --ext=ts,tsx src playwright",
-        "lint:fix": "eslint --ext=ts,tsx src playwright --fix",
+        "lint": "eslint src playwright",
+        "lint:fix": "eslint src playwright --fix",
         "format": "npm run prettier:write && npm run lint:fix"
     },
-    "eslintConfig": {
-        "extends": [
-            "@navikt/eslint-config-teamsykmelding",
-            "next/core-web-vitals"
-        ],
-        "rules": {
-            "@typescript-eslint/explicit-function-return-type": "off"
-        },
-        "overrides": [
-            {
-                "files": [
-                    "**/playwright/**/*.{js,ts,tsx}"
-                ],
-                "rules": {
-                    "testing-library/prefer-screen-queries": "off"
-                }
-            }
-        ]
-    },
-    "prettier": "@navikt/eslint-config-teamsykmelding/prettier"
+    "prettier": "@navikt/tsm-prettier"
 }

--- a/playwright/brodsmuler.spec.ts
+++ b/playwright/brodsmuler.spec.ts
@@ -12,8 +12,6 @@ import { forventBrodsmule, forventFlerebrodsmuler, klikkPaBrodsmule, standardBro
 import { expectKvittering, ExpectMeta } from './utils/user-expects'
 
 async function neiTilCookies(page: Page) {
-    await page.waitForLoadState('networkidle')
-
     const neiTilCookies = page.getByTestId('consent-banner-refuse-optional')
     if (await neiTilCookies.isVisible()) {
         await neiTilCookies.click()
@@ -24,6 +22,7 @@ test.describe('Tester Brodsmuler', () => {
     test.beforeAll(async ({ uuOptions }) => {
         uuOptions.skipUU = true
     })
+
     test('Burde vise brodsmuler på forsiden', async ({ page }) => {
         await page.goto('/syk/sykefravaer')
         await neiTilCookies(page)

--- a/playwright/cumulative-layout-shift.spec.ts
+++ b/playwright/cumulative-layout-shift.spec.ts
@@ -10,15 +10,12 @@ test.describe('Ytelse på hjemmesiden', () => {
         page.setDefaultTimeout(10000)
 
         const cls: number | null = await getCLS()
-
-        if (cls === null) {
-            expect(cls, 'CLS measurement failed: returned null').not.toBeNull()
-            return
-        }
+        expect(cls, 'CLS measurement failed: returned null').not.toBeNull()
+        const clsVerdi = cls as number
 
         expect(
-            cls,
-            `CLS score (${cls}) is too high on the homepage. Expected <= ${GOOD_CLS_THRESHOLD}.`,
+            clsVerdi,
+            `CLS score (${clsVerdi}) is too high on the homepage. Expected <= ${GOOD_CLS_THRESHOLD}.`,
         ).toBeLessThanOrEqual(GOOD_CLS_THRESHOLD)
     })
 })

--- a/playwright/flexjar.spec.ts
+++ b/playwright/flexjar.spec.ts
@@ -6,7 +6,6 @@ import { validerCLS } from './utils/cls-validering'
 test.describe('Flexjar', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('/syk/sykefravaer')
-        await page.waitForLoadState('networkidle')
     })
 
     test('Kan gi ja feedback', async ({ page, getCLS }) => {

--- a/playwright/keyboardnavigering.spec.ts
+++ b/playwright/keyboardnavigering.spec.ts
@@ -7,7 +7,7 @@ test.describe('Keyboard navigering', () => {
     test('Vi navigerer forsiden med mange elementer', async ({ page, browserName }) => {
         await page.goto('/syk/sykefravaer')
         await expect(page.locator('text=Du har en ny søknad om sykepenger')).toBeVisible()
-        await page.focus('#maincontent') // Fokuserer på første element i maincontent på samme måte som skiplenke fra dekoratøren
+        await page.locator('#maincontent').focus() // Fokuserer på første element i maincontent på samme måte som skiplenke fra dekoratøren
 
         const alertElement = await tabUntilFocusedContainsText(browserName, page, /Du har en ny søknad om sykepenger/)
 
@@ -46,7 +46,7 @@ test.describe('Keyboard navigering', () => {
         await page.keyboard.press('Enter')
         await expect(
             page.locator('text=Arbeidsgiveren har meldt inn at Albus Dumbledore skal følge deg opp mens du er syk.'),
-        ).not.toBeVisible()
+        ).toBeHidden()
 
         await tabUntilFocusedContainsText(browserName, page, 'Sykmeldinger')
 
@@ -60,7 +60,7 @@ test.describe('Keyboard navigering', () => {
         await expect(
             page.locator('text=Status i saken din om sykepenger: Vi venter på inntektsmelding fra Flex AS.'),
         ).toBeVisible()
-        await page.focus('#maincontent') // Fokuserer på første element i maincontent på samme måte som skiplenke fra dekoratøren
+        await page.locator('#maincontent').focus() // Fokuserer på første element i maincontent på samme måte som skiplenke fra dekoratøren
 
         // Første lenke er fokusert med riktig styling
         const statusLenke = await tabUntilFocusedContainsText(

--- a/playwright/snart-slutt-oppgave.spec.ts
+++ b/playwright/snart-slutt-oppgave.spec.ts
@@ -5,7 +5,6 @@ import { test } from './utils/fixtures'
 test.describe('Tester snart slutt oppgave', () => {
     test('Har riktig lenke', async ({ page }) => {
         await page.goto('/syk/sykefravaer?testperson=snart-slutt')
-        await page.waitForTimeout(10)
         const validLink = page.locator('main').locator('a:has-text("Snart slutt på sykepengene")').last()
 
         await expect(validLink).toBeVisible()

--- a/playwright/sykmelding/annet-survey.spec.ts
+++ b/playwright/sykmelding/annet-survey.spec.ts
@@ -41,7 +41,7 @@ test.describe('Annet arbeidssituasjon survey', () => {
         const modal = page.getByRole('dialog')
         await expect(modal).toBeVisible()
         await modal.getByRole('button', { name: 'Avbryt' }).click()
-        await expect(modal).not.toBeVisible()
+        await expect(modal).toBeHidden()
     })
 
     test('viser ikke survey-modal på kvittering når bruker valgte annen situasjon', async ({ page }) => {
@@ -50,7 +50,7 @@ test.describe('Annet arbeidssituasjon survey', () => {
         await velgForsikring('Nei')(page)
 
         await bekreftSykmelding(page)
-        await expect(page.getByRole('dialog')).not.toBeVisible()
+        await expect(page.getByRole('dialog')).toBeHidden()
     })
 
     test('kan sende inn survey på kvittering med valgt årsak', async ({ page }) => {
@@ -75,7 +75,7 @@ test.describe('Annet arbeidssituasjon survey', () => {
 
         await expect(modal.getByText('Takk for tilbakemeldingen!')).toBeVisible()
         await expect(modal.getByRole('button', { name: 'Lukk vindu' })).toBeVisible()
-        await expect(modal.getByRole('button', { name: 'Avbryt' })).not.toBeVisible()
+        await expect(modal.getByRole('button', { name: 'Avbryt' })).toBeHidden()
     })
 
     test('viser valideringsfeil på fritekst ved send med "Annen årsak" uten tekst', async ({ page }) => {
@@ -106,15 +106,15 @@ test.describe('Annet arbeidssituasjon survey', () => {
         const kvitteringUrl = page.url().replace(/\?.*/, '')
         await page.goto(kvitteringUrl)
 
-        await expect(page.getByRole('dialog')).not.toBeVisible()
+        await expect(page.getByRole('dialog')).toBeHidden()
     })
 
-    test.skip('viser ikke survey-modal på kvittering når toggle er av', async ({ page }) => {
+    test('viser ikke survey-modal på kvittering når toggle er av', async ({ page }) => {
         await page.goto(page.url().replace(/\?.*/, '') + '?toggle_flexjar-arbeidssituasjon-annet-survey=false')
         await opplysingeneStemmer(page)
         await velgArbeidssituasjon('annet')(page)
         await bekreftSykmelding(page)
 
-        await expect(page.getByRole('dialog')).not.toBeVisible()
+        await expect(page.getByRole('dialog')).toBeHidden()
     })
 })

--- a/playwright/sykmelding/avbrytSykmelding.spec.tsx
+++ b/playwright/sykmelding/avbrytSykmelding.spec.tsx
@@ -14,7 +14,7 @@ test.describe('Avbryt sykmelding', () => {
         await navigateToFirstSykmelding('tidligere', '100%')(page)
 
         await expect(page.getByText(/Sykmeldingen ble avbrutt av deg/)).toBeVisible()
-        await expect(page.getByRole('button', { name: /Avbryt sykmeldingen/ })).not.toBeVisible()
+        await expect(page.getByRole('button', { name: /Avbryt sykmeldingen/ })).toBeHidden()
         await expect(page.getByRole('button', { name: /GJØR UTFYLLINGEN PÅ NYTT/ })).toBeVisible()
     })
 
@@ -23,11 +23,11 @@ test.describe('Avbryt sykmelding', () => {
         await navigateToFirstSykmelding('tidligere', '100%')(page)
 
         await expect(page.getByText(/Sykmeldingen ble avbrutt av deg/)).toBeVisible()
-        await expect(page.getByRole('button', { name: /Avbryt sykmeldingen/ })).not.toBeVisible()
+        await expect(page.getByRole('button', { name: /Avbryt sykmeldingen/ })).toBeHidden()
 
         await page.getByRole('button', { name: /GJØR UTFYLLINGEN PÅ NYTT/ }).click()
 
-        await expect(page.getByText(/Sykmeldingen ble avbrutt av deg/)).not.toBeVisible()
+        await expect(page.getByText(/Sykmeldingen ble avbrutt av deg/)).toBeHidden()
         await expect(page.getByRole('button', { name: /Avbryt sykmeldingen/ })).toBeVisible()
     })
 

--- a/playwright/sykmelding/egenmeldingsdager.spec.tsx
+++ b/playwright/sykmelding/egenmeldingsdager.spec.tsx
@@ -52,6 +52,24 @@ function velgEgenmeldingsdager(egenmeldingsdagerHjelper: (page: Page) => Egenmel
     }
 }
 
+async function velgDagMedManedsnavigering(periode: EgenmeldingsdagerHjelper, dag: string): Promise<void> {
+    const dagKnapp = periode.dagButton(dag)
+    try {
+        await dagKnapp.click({ timeout: 300 })
+        return
+    } catch {
+        // Datoen er i en annen måned
+    }
+
+    try {
+        await periode.forrigeManedKnapp.click()
+        await dagKnapp.click({ timeout: 300 })
+    } catch {
+        await periode.nesteManedKnapp.click()
+        await dagKnapp.click()
+    }
+}
+
 test.describe('Egenmeldingsdager', () => {
     test.describe('Arbeidstaker', () => {
         test('burde kunne sende inn sykmelding med en periode med egenmelding', async ({ page }) => {
@@ -283,11 +301,7 @@ test.describe('Egenmeldingsdager', () => {
                 )(page)
                 await andrePeriode.svar.jaButton.click()
                 for (const dag of [`${testAaretFoer}-12-27`, `${testAaretFoer}-12-28`, `${testAaretFoer}-12-29`]) {
-                    const dagKnapp = andrePeriode.dagButton(dag)
-                    if (!(await dagKnapp.isVisible())) {
-                        await andrePeriode.forrigeManedKnapp.click()
-                    }
-                    await dagKnapp.click()
+                    await velgDagMedManedsnavigering(andrePeriode, dag)
                 }
                 await andrePeriode.videreButton.click()
 
@@ -314,22 +328,15 @@ test.describe('Egenmeldingsdager', () => {
 
                     const sykmeldingStartDatoTekst = toReadableDate(dateAdd(egenmeldingdatoMax, { days: 1 }))
                     const valgDatoString =
-                        periodeIndex === 1
-                            ? `Brukte du egenmelding hos Pontypandy Fire Service før du ble sykmeldt ${sykmeldingStartDatoTekst}?`
-                            : `Hadde du egenmeldingsdager før det igjen – altså mellom ${toReadableDate(egenmeldingdatoMin)} og ${toReadableDate(egenmeldingdatoMax)}?`
+                        [
+                            `Brukte du egenmelding hos Pontypandy Fire Service før du ble sykmeldt ${sykmeldingStartDatoTekst}?`,
+                            `Hadde du egenmeldingsdager før det igjen – altså mellom ${toReadableDate(egenmeldingdatoMin)} og ${toReadableDate(egenmeldingdatoMax)}?`,
+                        ][Math.min(1, periodeIndex - 1)] || ''
 
                     const periode = egenmeldingsdagerHjelper(valgDatoString)(page)
                     await periode.svar.jaButton.click()
 
-                    const datoKnapp = periode.dagButton(toDateString(egenmeldingdatoMin))
-                    if (!(await datoKnapp.isVisible())) {
-                        if (await periode.forrigeManedKnapp.isVisible()) {
-                            await periode.forrigeManedKnapp.click()
-                        } else {
-                            await periode.nesteManedKnapp.click()
-                        }
-                    }
-                    await datoKnapp.click()
+                    await velgDagMedManedsnavigering(periode, toDateString(egenmeldingdatoMin))
                     await periode.videreButton.click()
 
                     egenmeldingdatoMax = new TZDate(dateSub(egenmeldingdatoMin, { days: 1 }))

--- a/playwright/sykmelding/fiskere.spec.tsx
+++ b/playwright/sykmelding/fiskere.spec.tsx
@@ -21,7 +21,7 @@ test.describe('Arbeidssituasjon - Fiskere', () => {
                 '**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/er-utenfor-ventetid',
                 async (route) => {
                     if (route.request().method() === 'GET') {
-                        await page.waitForTimeout(5000)
+                        await new Promise((resolve) => setTimeout(resolve, 5000))
                         return route.continue()
                     }
                     return route.continue()
@@ -91,7 +91,7 @@ test.describe('Arbeidssituasjon - Fiskere', () => {
                 '**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/er-forste-sykmelding/**',
                 async (route) => {
                     if (route.request().method() === 'GET') {
-                        await page.waitForTimeout(5000)
+                        await new Promise((resolve) => setTimeout(resolve, 5000))
                         return route.continue()
                     }
                     return route.continue()
@@ -147,7 +147,7 @@ test.describe('Arbeidssituasjon - Fiskere', () => {
             })(page)
             await fillOutFisker('Blad A', 'Lott')(page)
 
-            await expect(page.getByRole('region', { name: 'Fravær før sykmeldingen' })).not.toBeVisible()
+            await expect(page.getByRole('region', { name: 'Fravær før sykmeldingen' })).toBeHidden()
         })
 
         test('Hyre, skal oppføre seg som arbeidsgiver', async ({ page }) => {

--- a/playwright/sykmelding/frilanser.spec.tsx
+++ b/playwright/sykmelding/frilanser.spec.tsx
@@ -21,7 +21,7 @@ test.describe('Frilanser', () => {
                 '**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/er-utenfor-ventetid',
                 async (route) => {
                     if (route.request().method() === 'GET') {
-                        await page.waitForTimeout(5000)
+                        await new Promise((resolve) => setTimeout(resolve, 5000))
                         return route.continue()
                     }
                     return route.continue()
@@ -98,7 +98,7 @@ test.describe('Frilanser', () => {
                 '**/api/flex-sykmeldinger-backend/api/v1/sykmeldinger/*/er-forste-sykmelding/**',
                 async (route) => {
                     if (route.request().method() === 'GET') {
-                        await page.waitForTimeout(5000)
+                        await new Promise((resolve) => setTimeout(resolve, 5000))
                         return route.continue()
                     }
                     return route.continue()

--- a/playwright/sykmelding/general.spec.ts
+++ b/playwright/sykmelding/general.spec.ts
@@ -48,6 +48,6 @@ test.describe('sykmeldingtester ikke relatert til en spesifikk bruker', () => {
         await expect(page.getByRole('region', { name: 'Flere opplysninger' })).toBeVisible()
         await expect(page.getByRole('region', { name: 'Se hva som sendes til jobben din' })).toBeVisible()
 
-        await expect(page.getByRole('region', { name: 'Dine svar' })).not.toBeVisible()
+        await expect(page.getByRole('region', { name: 'Dine svar' })).toBeHidden()
     })
 })

--- a/playwright/sykmelding/kvittering.spec.tsx
+++ b/playwright/sykmelding/kvittering.spec.tsx
@@ -13,6 +13,6 @@ test.describe('Kvittering', () => {
             page.locator(
                 'text=Hvis du ønsker å endre egenmeldingsdager etter at du har sendt sykmeldingen, må du ta kontakt med arbeidsgiver.',
             ),
-        ).not.toBeVisible()
+        ).toBeHidden()
     })
 })

--- a/playwright/sykmelding/kvitteringVentetid.spec.tsx
+++ b/playwright/sykmelding/kvitteringVentetid.spec.tsx
@@ -57,6 +57,6 @@ test.describe('Informasjon om ventetid', () => {
         await sendSykmelding(page)
 
         await expect(page.getByText('Sykmeldingen ble sendt til Pontypandy Fire Service')).toBeVisible()
-        await expect(page.getByText('Hva skjer videre?')).not.toBeVisible()
+        await expect(page.getByText('Hva skjer videre?')).toBeHidden()
     })
 })

--- a/playwright/sykmelding/optIn.spec.tsx
+++ b/playwright/sykmelding/optIn.spec.tsx
@@ -67,7 +67,7 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
 
         await apneReadmore(page, OPT_IN_READ_MORE)
         await expect(page.getByText('Vi har opprettet søknad for denne perioden')).toBeVisible()
-        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
+        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).toBeHidden()
     })
 
     test('viser info-alert etter vellykket opt-in', async ({ page }) => {
@@ -116,7 +116,7 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
 
         await apneReadmore(page, OPT_IN_READ_MORE)
         await expect(page.getByText('Beklager, en feil oppstod. Vennligst prøv igjen senere')).toBeVisible()
-        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
+        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).toBeHidden()
     })
 
     test('viser feilvarsel når opt-in-kallet feiler', async ({ page }) => {
@@ -146,6 +146,6 @@ test.describe('Opt-in søknad for næringsdrivende/frilanser', () => {
 
         await apneReadmore(page, OPT_IN_READ_MORE)
         await expect(page.getByText('Søknadsfristen er gått ut')).toBeVisible()
-        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).not.toBeVisible()
+        await expect(page.getByRole('button', { name: 'Jeg vil søke om sykepenger' })).toBeHidden()
     })
 })

--- a/playwright/sykmelding/selvstendigNaringsdrivende.spec.tsx
+++ b/playwright/sykmelding/selvstendigNaringsdrivende.spec.tsx
@@ -86,7 +86,7 @@ test.describe('Selvstendig næringsdrivende', () => {
                 navigateToFirstAndPickSituasjon,
             )(page)
 
-            await expect(page.getByRole('region', { name: 'Fravær før sykmeldingen' })).not.toBeVisible()
+            await expect(page.getByRole('region', { name: 'Fravær før sykmeldingen' })).toBeHidden()
         })
     })
 

--- a/playwright/sykmelding/sykmeldinger.spec.tsx
+++ b/playwright/sykmelding/sykmeldinger.spec.tsx
@@ -5,8 +5,6 @@ test.describe('Sykmeldinger landingsside', () => {
     test('skal feile med feilmelding ved API-feil', async ({ page }) => {
         await gotoScenario('feilmelding')(page)
 
-        await page.waitForSelector('text=Vi har problemer med baksystemene for øyeblikket.')
-
         await expect(page.locator('text=Vi har problemer med baksystemene for øyeblikket.')).toBeVisible()
     })
 

--- a/playwright/sykmelding/uriktigeOpplysninger.spec.tsx
+++ b/playwright/sykmelding/uriktigeOpplysninger.spec.tsx
@@ -58,7 +58,7 @@ test.describe('Uriktige opplysninger', () => {
         await navigateToFirstSykmelding('nye', '100%')(page)
         await getRadioInGroup(page)({ name: 'Stemmer opplysningene?' }, { name: 'Nei' }).click()
 
-        await expect(page.getByText('Hvilken arbeidssituasjon gjelder sykmeldingen for?')).not.toBeVisible()
+        await expect(page.getByText('Hvilken arbeidssituasjon gjelder sykmeldingen for?')).toBeHidden()
         await expect(page.getByRole('button', { name: /^(Send|Bekreft) sykmelding/ })).toBeVisible()
     })
 
@@ -131,12 +131,12 @@ test.describe('Uriktige opplysninger', () => {
             page.getByText(
                 'Senere, når du skal fylle ut søknaden om sykepenger, skriver du bare inn hvor mye du faktisk jobbet.',
             ),
-        ).not.toBeVisible()
+        ).toBeHidden()
         await expect(
             page.getByText(
                 'Hvis sykmeldingen senere skal forlenges, må du gi beskjed til den som sykmelder deg om at diagnosen er feil.',
             ),
-        ).not.toBeVisible()
+        ).toBeHidden()
     })
 })
 
@@ -161,8 +161,8 @@ function opplysningNotCorrect(
 
 async function expectNotUsable(page: Page): Promise<void> {
     await expect(page.getByRole('heading', { name: 'Du kan ikke bruke denne sykmeldingen' })).toBeVisible()
-    await expect(page.getByText('Hvilken arbeidssituasjon gjelder sykmeldingen for?')).not.toBeVisible()
-    await expect(page.getByRole('button', { name: /^(Send|Bekreft) sykmelding/ })).not.toBeVisible()
+    await expect(page.getByText('Hvilken arbeidssituasjon gjelder sykmeldingen for?')).toBeHidden()
+    await expect(page.getByRole('button', { name: /^(Send|Bekreft) sykmelding/ })).toBeHidden()
 }
 
 function expectUseable(explanationText: string) {

--- a/playwright/sykmelding/ventetid-opt-in.spec.ts
+++ b/playwright/sykmelding/ventetid-opt-in.spec.ts
@@ -40,8 +40,8 @@ test.describe('Opt-in info vises kun for sykmeldinger innenfor ventetiden', () =
                 .click()
 
             await harSynligOverskrift(page, 'Sykmeldingen er sendt', 1)
-            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).not.toBeVisible()
-            await expect(page.getByText(OPT_IN_READ_MORE)).not.toBeVisible()
+            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).toBeHidden()
+            await expect(page.getByText(OPT_IN_READ_MORE)).toBeHidden()
         })
     })
 
@@ -70,8 +70,8 @@ test.describe('Opt-in info vises kun for sykmeldinger innenfor ventetiden', () =
             await bekreftSykmelding(page)
 
             await harSynligOverskrift(page, 'Sykmeldingen er sendt', 1)
-            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).not.toBeVisible()
-            await expect(page.getByText(OPT_IN_READ_MORE)).not.toBeVisible()
+            await expect(page.getByRole('heading', { name: VENTETID_HEADING })).toBeHidden()
+            await expect(page.getByText(OPT_IN_READ_MORE)).toBeHidden()
         })
     })
 })

--- a/playwright/utils/custom-matchers.ts
+++ b/playwright/utils/custom-matchers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { expect } from '@playwright/test'
 import { Locator } from 'playwright-core'
 
@@ -12,8 +11,8 @@ expect.extend({
             }
         }
 
-        const descriptiveText = await locator.page().locator(`#${describedId}`).textContent()
-        expect(descriptiveText, { message: 'Descriptive text does not match' }).toEqual(expectedText)
+        const descriptiveLocator = locator.page().locator(`#${describedId}`)
+        await expect(descriptiveLocator, { message: 'Descriptive text does not match' }).toHaveText(expectedText ?? '')
 
         return {
             message: () => 'passed',

--- a/playwright/utils/fixtures.ts
+++ b/playwright/utils/fixtures.ts
@@ -25,7 +25,6 @@ export const test = base.extend<{
             await measureCLSWithWebVitals(page)
         }
 
-        // eslint-disable-next-line react-hooks/rules-of-hooks
         await use(async () => {
             if (!clsOptions.enableCLS) {
                 return null

--- a/playwright/utils/user-expects.ts
+++ b/playwright/utils/user-expects.ts
@@ -29,7 +29,7 @@ export function expectKvittering(opts: {
             'Hvis du ønsker å endre egenmeldingsdager etter at du har sendt sykmeldingen, må du ta kontakt med arbeidsgiver.'
 
         if (opts.egenmeldingsdagerInfo === ExpectMeta.NotInDom) {
-            await expect(page.getByText(egenmeldingsdagerInfoText)).not.toBeVisible()
+            await expect(page.getByText(egenmeldingsdagerInfoText)).toBeHidden()
         } else {
             await expect(page.getByText(egenmeldingsdagerInfoText)).toBeVisible()
         }
@@ -95,9 +95,7 @@ export function expectDineSvar(svar: {
 
         if (svar.arbeidsledig) {
             if (svar.arbeidsledig === ExpectMeta.NotInDom) {
-                await expect(
-                    getInfoItem('Hvilken arbeidsgiver har du blitt arbeidsledig fra?')(region),
-                ).not.toBeVisible()
+                await expect(getInfoItem('Hvilken arbeidsgiver har du blitt arbeidsledig fra?')(region)).toBeHidden()
             } else {
                 await expect(getInfoItem('Hvilken arbeidsgiver har du blitt arbeidsledig fra?')(region)).toHaveText(
                     new RegExp(svar.arbeidsledig.arbeidsledigFraOrgnummer, 'i'),
@@ -116,12 +114,12 @@ export function expectDineSvar(svar: {
         if (svar.narmesteleder === ExpectMeta.NotInDom) {
             await expect(
                 getInfoItem(new RegExp(`som skal følge deg opp på jobben mens du er syk?`))(region),
-            ).not.toBeVisible()
+            ).toBeHidden()
         }
 
         if (svar.egenmeldingsdager) {
             if (svar.egenmeldingsdager === ExpectMeta.NotInDom) {
-                await expect(getInfoItem(new RegExp(`Brukte du egenmelding hos`))(region)).not.toBeVisible()
+                await expect(getInfoItem(new RegExp(`Brukte du egenmelding hos`))(region)).toBeHidden()
             } else if ('svar' in svar.egenmeldingsdager && svar.egenmeldingsdager.svar === 'Nei') {
                 await expect(
                     getInfoItem(new RegExp(`Brukte du egenmelding hos ${svar.egenmeldingsdager.arbeidsgiver}`, 'i'))(
@@ -144,7 +142,7 @@ export function expectDineSvar(svar: {
 
         if (svar.selvstendig) {
             if (svar.selvstendig.egenmeldingsperioder === ExpectMeta.NotInDom) {
-                await expect(getInfoItem('Var du syk og borte fra jobb før du ble sykmeldt')(page)).not.toBeVisible()
+                await expect(getInfoItem('Var du syk og borte fra jobb før du ble sykmeldt')(page)).toBeHidden()
             } else if (svar.selvstendig.egenmeldingsperioder === 'Nei') {
                 await expect(getInfoItem('Var du syk og borte fra jobb før du ble sykmeldt')(page)).toHaveText(/Nei/)
             } else {
@@ -160,7 +158,7 @@ export function expectDineSvar(svar: {
             if (svar.selvstendig.forsikring === ExpectMeta.NotInDom) {
                 await expect(
                     getInfoItem('Har du forsikring som gjelder for de første 16 dagene av sykefraværet?')(page),
-                ).not.toBeVisible()
+                ).toBeHidden()
             } else {
                 await expect(
                     getInfoItem('Har du forsikring som gjelder for de første 16 dagene av sykefraværet?')(page),
@@ -170,7 +168,7 @@ export function expectDineSvar(svar: {
 
         if (svar.fisker) {
             if (svar.fisker === ExpectMeta.NotInDom) {
-                await expect(getInfoItem('Velg blad')(page)).not.toBeVisible()
+                await expect(getInfoItem('Velg blad')(page)).toBeHidden()
             } else {
                 await expect(getInfoItem('Velg blad')(page)).toHaveText(new RegExp(`Blad ${svar.fisker.blad}`, 'i'))
                 await expect(getInfoItem('Mottar du lott eller er du på hyre?')(page)).toHaveText(

--- a/playwright/utils/uuvalidering.ts
+++ b/playwright/utils/uuvalidering.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { expect, Page, TestInfo } from '@playwright/test'
 import { AxeBuilder } from '@axe-core/playwright'
 
@@ -46,8 +45,9 @@ export async function validerAxe(page: Page, testInfo: TestInfo, disableRules: s
                         // Highlight elementet med rød ramme
                         await element.highlight()
 
-                        // Vent litt for at highlight skal vises
-                        await page.waitForTimeout(100)
+                        await page.evaluate(
+                            () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+                        )
 
                         // Ta screenshot av hele viewporten for å få kontekst
                         const fullScreenshot = await page.screenshot({
@@ -66,7 +66,7 @@ export async function validerAxe(page: Page, testInfo: TestInfo, disableRules: s
                             body: elementScreenshot,
                         })
                     }
-                } catch (error) {
+                } catch {
                     // Ignorer hvis vi ikke kan ta screenshot av elementet
                     console.log(`Kunne ikke ta screenshot av element: ${node.target.join(' ')}`)
                 }
@@ -93,11 +93,10 @@ export async function validerAxe(page: Page, testInfo: TestInfo, disableRules: s
         console.log('==================\n')
         console.log(`${violations.length} UU-violation(s) detected - se attachments i Playwright GUI for detaljer`)
 
-        expect(violations.length, `${violations.length} UU-violation(s) funnet:\n\n${errorMessage}`).toBe(0)
+        expect(violations, `${violations.length} UU-violation(s) funnet:\n\n${errorMessage}`).toHaveLength(0)
     }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function generateHtmlReport(violations: any[], url: string): string {
     return `
 <!DOCTYPE html>
@@ -181,7 +180,6 @@ function generateHtmlReport(violations: any[], url: string): string {
                 <div class="element-list">
                     ${violation.nodes
                         .map(
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
                             (node: { target: any[] }) => `
                         <div class="element">${node.target.join(' ')}</div>
                     `,

--- a/playwright/utils/web-vitals-setup.ts
+++ b/playwright/utils/web-vitals-setup.ts
@@ -18,7 +18,6 @@ export async function measureCLSWithWebVitals(page: Page): Promise<void> {
     })
 
     await page.evaluate(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const win = window as any
 
         if (win.webVitals && typeof win.webVitals.onCLS === 'function') {
@@ -43,10 +42,9 @@ export async function getCLSValue(page: Page): Promise<number | null> {
         document.dispatchEvent(pagehideEvent)
     })
 
-    await page.waitForTimeout(500)
+    await page.evaluate(() => new Promise<void>((resolve) => window.setTimeout(() => resolve(), 500)))
 
     return await page.evaluate(() => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const win = window as any
         const values = win._clsValues || []
         return values.length > 0 ? values[values.length - 1] : 0

--- a/playwright/venter-pa-inntektsmelding.spec.ts
+++ b/playwright/venter-pa-inntektsmelding.spec.ts
@@ -43,6 +43,6 @@ test.describe('Tester inntektsmelding', () => {
         const closeButton = oppgaver.locator('.aksel-alert .aksel-button')
         await closeButton.click()
 
-        await expect(oppgaver).not.toBeVisible()
+        await expect(oppgaver).toBeHidden()
     })
 })

--- a/src/components/Sykmelding/SykmeldingerArbeidsgiver/SykmeldingArbeidsgiver.test.tsx
+++ b/src/components/Sykmelding/SykmeldingerArbeidsgiver/SykmeldingArbeidsgiver.test.tsx
@@ -73,7 +73,6 @@ describe('SykmeldingViewArbeidsgiver', () => {
     it('Behandler skal bruke korrekt navn korrekt formatert', () => {
         render(<SykmeldingArbeidsgiver sykmelding={minimalSykmelding} />)
 
-        // eslint-disable-next-line testing-library/no-node-access
         expect(screen.getByText(/Sykmeldingen ble skrevet av/).parentElement).toHaveTextContent(/Frida Perma Frost/)
     })
 })

--- a/src/components/arbeidssituasjon/arbeidssituasjonHjelpefunksjoner.ts
+++ b/src/components/arbeidssituasjon/arbeidssituasjonHjelpefunksjoner.ts
@@ -31,7 +31,7 @@ export const finnAktuelleArbeidsgivere = (
     const unikeArbeidsgiver = new Set(
         sykmeldingerMedAktivLederEllerMindreEnnTreMaanederGammel
             .filter((syk) => syk.sykmeldingStatus.arbeidsgiver)
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
             .map((syk) => syk.sykmeldingStatus.arbeidsgiver!.orgnummer),
     )
 

--- a/src/components/flexjar/AnnetArbeidssituasjonSurvey.tsx
+++ b/src/components/flexjar/AnnetArbeidssituasjonSurvey.tsx
@@ -47,7 +47,6 @@ export function AnnetArbeidssituasjonSurvey({ onTakk }: { onTakk?: () => void })
     useEffect(() => {
         if (!valgtArsak) return
         sendFeedback()
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [valgtArsak])
 
     const handleSend = () => {

--- a/src/components/flexjar/flexjar-felles.tsx
+++ b/src/components/flexjar/flexjar-felles.tsx
@@ -76,7 +76,7 @@ export function FlexjarFelles({
                     knappeklikk()
                 }
                 return true
-            } catch (e) {
+            } catch {
                 return false
             }
         },
@@ -98,7 +98,6 @@ export function FlexjarFelles({
     useEffect(() => {
         fetchFeedback().catch()
         // kan ikke bruke fetchFeedback som dependency, da blir det dobble kall
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeState])
 
     useEffect(() => {

--- a/src/components/lenker/skalViseOppfoelgingsplanLenke.test.ts
+++ b/src/components/lenker/skalViseOppfoelgingsplanLenke.test.ts
@@ -12,7 +12,6 @@ it('Returnerer false hvis ingenting er fetchet', () => {
 })
 
 it('Returnerer true hvis undefined sykmeldinger men oppfølgingsplaner', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const skalVise = skalViseOppfoelgingsplanLenke(undefined, [{ id: 1 } as any], testDato)
     expect(skalVise).toEqual(true)
 })

--- a/src/components/oppgaver/Oppgaver.tsx
+++ b/src/components/oppgaver/Oppgaver.tsx
@@ -54,7 +54,7 @@ export const EnkeltOppgaveAlert = ({ oppgave, pushLukket }: EnkeltOppgaveAlertPr
                                 },
                             },
                         )
-                    } catch (e) {
+                    } catch {
                         // Viser ikke feilmelding til bruker siden lukking kan funke neste gang hen prøver.
                         // Feilen blir logget i fetchMedRequestId.
                     } finally {

--- a/src/components/umami/umami.ts
+++ b/src/components/umami/umami.ts
@@ -21,7 +21,6 @@ export const logEvent = (eventName: validEventNames, eventData: Record<string, s
                 eventData,
             }).catch((e) => logger.warn(`Feil ved umami logging`, e))
         } else if (!isProd() && isOpplaering()) {
-            // eslint-disable-next-line no-console
             console.log(`Logger ${eventName} - Event properties: ${JSON.stringify(eventData)}!`)
         }
     }

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+    const content: Record<string, string>
+    export default content
+}

--- a/src/pages/api/flex-sykmeldinger-backend/SendSykmeldingRequest.ts
+++ b/src/pages/api/flex-sykmeldinger-backend/SendSykmeldingRequest.ts
@@ -2,8 +2,6 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { logger } from '@navikt/next-logger'
 import { requestOboToken } from '@navikt/oasis'
 
-import { isValidSykmeldingId } from 'src/utils/sykmeldingUtils'
-
 import { SykmeldingUserEventV3Api } from '../../../server/api-models/SendSykmelding'
 import { getServerEnv } from '../../../utils/env'
 import { Brukerinformasjon } from '../../../server/api-models/Brukerinformasjon'
@@ -11,6 +9,7 @@ import { MuterbarSykmelding } from '../../../server/api-models/sykmelding/Muterb
 import { fetchMedRequestId } from '../../../utils/fetch'
 import { mapSendSykmeldingValuesToV3Api } from '../../../server/sendSykmeldingMapping'
 import { SendSykmeldingValues } from '../../../server/api-models/SendSykmeldingValues'
+import { isValidSykmeldingId } from '../../../utils/sykmeldingUtils'
 
 const flexSykmeldingerHostname = 'flex-sykmeldinger-backend'
 

--- a/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
+++ b/src/pages/sykmeldinger/[sykmeldingId]/kvittering.tsx
@@ -41,7 +41,7 @@ function SykmeldingkvitteringPage(): ReactElement {
             setSurveyModalApen(true)
             void router.replace({ pathname: router.pathname, query: { sykmeldingId } }, undefined, { shallow: true })
         }
-    }, [router.query.visSurvey]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [router.query.visSurvey])
 
     function handleSurveyTakk() {
         setSurveyTakk(true)

--- a/src/utils/test/testUtils.tsx
+++ b/src/utils/test/testUtils.tsx
@@ -7,9 +7,8 @@ import { FlagProvider } from '../../toggles/context'
 import * as customQueries from './customQueries'
 
 type ProviderProps = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly initialState?: any[]
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     readonly mocks?: any[]
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2015",
         "lib": ["dom", "dom.iterable", "esnext"],
         "allowJs": true,
         "skipLibCheck": true,
@@ -18,7 +18,6 @@
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
         "incremental": true,
-        "baseUrl": ".",
         "plugins": [
             {
                 "name": "next"


### PR DESCRIPTION
Samler ESLint v9- og TypeScript v6-oppgraderingen og flat config-migreringen i én PR mot main, squashet til én commit for enkel oversikt over hva som merges.

Inneholder:
- Oppgradering av ESLint til v9 og TypeScript til v6
- Migrering til ESLint flat config (`eslint.config.mjs`) basert på `eslint-config-next`-presets (core-web-vitals + typescript), på linje med spinnsyn-frontend
- Nye react-hooks v6-regler (React Compiler) satt til warn, samt no-console og no-explicit-any som warn
- Tilpasning av Playwright-tester og -utils for ESLint 9

Erstatter og lukker #3308 (tidligere stacked PR).