### PR TITLE
Fiks punktliste-visning i uriktige opplysninger

### DIFF
--- a/src/components/SendSykmelding/FormSections/OpplysningerRiktige/UriktigeOpplysningerInfo.tsx
+++ b/src/components/SendSykmelding/FormSections/OpplysningerRiktige/UriktigeOpplysningerInfo.tsx
@@ -13,7 +13,7 @@ function UriktigeOpplysningerInfo({ uriktigeOpplysninger }: UriktigeOpplysninger
             <Heading spacing size="small" level="3">
                 Du kan fortsatt bruke sykmeldingen
             </Heading>
-            <ul>
+            <ul className="list-outside pl-5">
                 {uriktigeOpplysninger.map((value) => (
                     <li key={value} className="mt-4">
                         {uriktigeOpplysningerEnumToText(value)}


### PR DESCRIPTION
Retter feil der kulepunktet ble vist over teksten i infoboksen «Du kan fortsatt bruke sykmeldingen». Overstyrer `<ul>` til `list-outside` med venstre-padding, slik at kulen ligger ved siden av overskriften i hvert listepunkt.